### PR TITLE
[HIPIFY][feature] Local header hipification via Clang PPCallbacks (experimental, opt-in) - Part 1

### DIFF
--- a/src/ArgParse.cpp
+++ b/src/ArgParse.cpp
@@ -226,13 +226,8 @@ cl::opt<bool> HipDnnSupport("hipdnn",
   cl::init(false),
   cl::cat(ToolTemplateCategory));
 
-cl::opt<bool> OptLocalHeaders("local-headers",
-  cl::desc("Enable hipification of quoted local headers (non-recursive)"),
-  cl::init(false),
-  cl::cat(ToolTemplateCategory));
-
-cl::opt<bool> OptLocalHeadersRecursive("local-headers-recursive",
-  cl::desc("Enable hipification of quoted local headers recursively"),
+cl::opt<bool> SkipLocalHeaders("skip-local-headers",
+  cl::desc("Skip implicit hipification of local (quoted) headers included in the main source file"),
   cl::init(false),
   cl::cat(ToolTemplateCategory));
 
@@ -264,8 +259,7 @@ const std::vector<std::string> hipifyOptions {
   std::string(NoWarningsUndocumented.ArgStr),
   std::string(HipifyAMAP.ArgStr),
   std::string(HipDnnSupport.ArgStr),
-  std::string(OptLocalHeaders.ArgStr),
-  std::string(OptLocalHeadersRecursive.ArgStr),
+  std::string(SkipLocalHeaders.ArgStr),
 };
 
 const std::vector<std::string> hipifyOptionsWithTwoArgs {

--- a/src/ArgParse.cpp
+++ b/src/ArgParse.cpp
@@ -226,46 +226,46 @@ cl::opt<bool> HipDnnSupport("hipdnn",
   cl::init(false),
   cl::cat(ToolTemplateCategory));
 
-cl::opt<bool> OptLocalHeaders(
-    "local-headers",
-    cl::desc("Enable hipification of quoted local headers (non-recursive)"),
-    cl::init(false), cl::cat(ToolTemplateCategory));
+cl::opt<bool> OptLocalHeaders("local-headers",
+  cl::desc("Enable hipification of quoted local headers (non-recursive)"),
+  cl::init(false),
+  cl::cat(ToolTemplateCategory));
 
-cl::opt<bool> OptLocalHeadersRecursive(
-    "local-headers-recursive",
-    cl::desc("Enable hipification of quoted local headers recursively"),
-    cl::init(false), cl::cat(ToolTemplateCategory));
+cl::opt<bool> OptLocalHeadersRecursive("local-headers-recursive",
+  cl::desc("Enable hipification of quoted local headers recursively"),
+  cl::init(false),
+  cl::cat(ToolTemplateCategory));
 
 cl::extrahelp CommonHelp(ct::CommonOptionsParser::HelpMessage);
 
-const std::vector<std::string> hipifyOptions{
-    std::string(PrintStatsCSV.ArgStr),
-    std::string(PrintStats.ArgStr),
-    std::string(SkipExcludedPPConditionalBlocks.ArgStr),
-    std::string(DefaultPreprocessor.ArgStr),
-    std::string(HipKernelExecutionSyntax.ArgStr),
-    std::string(CudaKernelExecutionSyntax.ArgStr),
-    std::string(GeneratePerl.ArgStr),
-    std::string(GeneratePython.ArgStr),
-    std::string(TranslateToRoc.ArgStr),
-    std::string(TranslateToMIOpen.ArgStr),
-    std::string(GenerateMarkdown.ArgStr),
-    std::string(GenerateCSV.ArgStr),
-    std::string(NoBackup.ArgStr),
-    std::string(NoOutput.ArgStr),
-    std::string(Inplace.ArgStr),
-    std::string(Examine.ArgStr),
-    std::string(SaveTemps.ArgStr),
-    std::string(DocFormat.ArgStr),
-    std::string(DocRoc.ArgStr),
-    std::string(Experimental.ArgStr),
-    std::string(Versions.ArgStr),
-    std::string(NoUndocumented.ArgStr),
-    std::string(NoWarningsUndocumented.ArgStr),
-    std::string(HipifyAMAP.ArgStr),
-    std::string(HipDnnSupport.ArgStr),
-    std::string(OptLocalHeaders.ArgStr),
-    std::string(OptLocalHeadersRecursive.ArgStr),
+const std::vector<std::string> hipifyOptions {
+  std::string(PrintStatsCSV.ArgStr),
+  std::string(PrintStats.ArgStr),
+  std::string(SkipExcludedPPConditionalBlocks.ArgStr),
+  std::string(DefaultPreprocessor.ArgStr),
+  std::string(HipKernelExecutionSyntax.ArgStr),
+  std::string(CudaKernelExecutionSyntax.ArgStr),
+  std::string(GeneratePerl.ArgStr),
+  std::string(GeneratePython.ArgStr),
+  std::string(TranslateToRoc.ArgStr),
+  std::string(TranslateToMIOpen.ArgStr),
+  std::string(GenerateMarkdown.ArgStr),
+  std::string(GenerateCSV.ArgStr),
+  std::string(NoBackup.ArgStr),
+  std::string(NoOutput.ArgStr),
+  std::string(Inplace.ArgStr),
+  std::string(Examine.ArgStr),
+  std::string(SaveTemps.ArgStr),
+  std::string(DocFormat.ArgStr),
+  std::string(DocRoc.ArgStr),
+  std::string(Experimental.ArgStr),
+  std::string(Versions.ArgStr),
+  std::string(NoUndocumented.ArgStr),
+  std::string(NoWarningsUndocumented.ArgStr),
+  std::string(HipifyAMAP.ArgStr),
+  std::string(HipDnnSupport.ArgStr),
+  std::string(OptLocalHeaders.ArgStr),
+  std::string(OptLocalHeadersRecursive.ArgStr),
 };
 
 const std::vector<std::string> hipifyOptionsWithTwoArgs {

--- a/src/ArgParse.cpp
+++ b/src/ArgParse.cpp
@@ -226,40 +226,46 @@ cl::opt<bool> HipDnnSupport("hipdnn",
   cl::init(false),
   cl::cat(ToolTemplateCategory));
 
-cl::opt<bool> SkipLocalHeaders("skip-local-headers",
-  cl::desc("Skip implicit hipification of local (quoted) headers included in the main source file"),
-  cl::init(false),
-  cl::cat(ToolTemplateCategory));
+cl::opt<bool> OptLocalHeaders(
+    "local-headers",
+    cl::desc("Enable hipification of quoted local headers (non-recursive)"),
+    cl::init(false), cl::cat(ToolTemplateCategory));
+
+cl::opt<bool> OptLocalHeadersRecursive(
+    "local-headers-recursive",
+    cl::desc("Enable hipification of quoted local headers recursively"),
+    cl::init(false), cl::cat(ToolTemplateCategory));
 
 cl::extrahelp CommonHelp(ct::CommonOptionsParser::HelpMessage);
 
-const std::vector<std::string> hipifyOptions {
-  std::string(PrintStatsCSV.ArgStr),
-  std::string(PrintStats.ArgStr),
-  std::string(SkipExcludedPPConditionalBlocks.ArgStr),
-  std::string(DefaultPreprocessor.ArgStr),
-  std::string(HipKernelExecutionSyntax.ArgStr),
-  std::string(CudaKernelExecutionSyntax.ArgStr),
-  std::string(GeneratePerl.ArgStr),
-  std::string(GeneratePython.ArgStr),
-  std::string(TranslateToRoc.ArgStr),
-  std::string(TranslateToMIOpen.ArgStr),
-  std::string(GenerateMarkdown.ArgStr),
-  std::string(GenerateCSV.ArgStr),
-  std::string(NoBackup.ArgStr),
-  std::string(NoOutput.ArgStr),
-  std::string(Inplace.ArgStr),
-  std::string(Examine.ArgStr),
-  std::string(SaveTemps.ArgStr),
-  std::string(DocFormat.ArgStr),
-  std::string(DocRoc.ArgStr),
-  std::string(Experimental.ArgStr),
-  std::string(Versions.ArgStr),
-  std::string(NoUndocumented.ArgStr),
-  std::string(NoWarningsUndocumented.ArgStr),
-  std::string(HipifyAMAP.ArgStr),
-  std::string(HipDnnSupport.ArgStr),
-  std::string(SkipLocalHeaders.ArgStr),
+const std::vector<std::string> hipifyOptions{
+    std::string(PrintStatsCSV.ArgStr),
+    std::string(PrintStats.ArgStr),
+    std::string(SkipExcludedPPConditionalBlocks.ArgStr),
+    std::string(DefaultPreprocessor.ArgStr),
+    std::string(HipKernelExecutionSyntax.ArgStr),
+    std::string(CudaKernelExecutionSyntax.ArgStr),
+    std::string(GeneratePerl.ArgStr),
+    std::string(GeneratePython.ArgStr),
+    std::string(TranslateToRoc.ArgStr),
+    std::string(TranslateToMIOpen.ArgStr),
+    std::string(GenerateMarkdown.ArgStr),
+    std::string(GenerateCSV.ArgStr),
+    std::string(NoBackup.ArgStr),
+    std::string(NoOutput.ArgStr),
+    std::string(Inplace.ArgStr),
+    std::string(Examine.ArgStr),
+    std::string(SaveTemps.ArgStr),
+    std::string(DocFormat.ArgStr),
+    std::string(DocRoc.ArgStr),
+    std::string(Experimental.ArgStr),
+    std::string(Versions.ArgStr),
+    std::string(NoUndocumented.ArgStr),
+    std::string(NoWarningsUndocumented.ArgStr),
+    std::string(HipifyAMAP.ArgStr),
+    std::string(HipDnnSupport.ArgStr),
+    std::string(OptLocalHeaders.ArgStr),
+    std::string(OptLocalHeadersRecursive.ArgStr),
 };
 
 const std::vector<std::string> hipifyOptionsWithTwoArgs {

--- a/src/ArgParse.h
+++ b/src/ArgParse.h
@@ -70,5 +70,4 @@ extern cl::opt<bool> NoUndocumented;
 extern cl::opt<bool> NoWarningsUndocumented;
 extern cl::opt<bool> HipifyAMAP;
 extern cl::opt<bool> HipDnnSupport;
-extern cl::opt<bool> OptLocalHeaders;
-extern cl::opt<bool> OptLocalHeadersRecursive;
+extern cl::opt<bool> SkipLocalHeaders;

--- a/src/ArgParse.h
+++ b/src/ArgParse.h
@@ -70,4 +70,5 @@ extern cl::opt<bool> NoUndocumented;
 extern cl::opt<bool> NoWarningsUndocumented;
 extern cl::opt<bool> HipifyAMAP;
 extern cl::opt<bool> HipDnnSupport;
-extern cl::opt<bool> SkipLocalHeaders;
+extern cl::opt<bool> OptLocalHeaders;
+extern cl::opt<bool> OptLocalHeadersRecursive;

--- a/src/LocalHeader.cpp
+++ b/src/LocalHeader.cpp
@@ -186,13 +186,16 @@ bool hipifyLocalHeaders(const std::string &mainSourceAbsPath,
            << ": " << sys::path::filename(initial[i]) << "\n";
   }
 
-  std::vector<std::string> work(initial.begin(), initial.end());
+  std::vector<std::pair<std::string, std::string>> work;
+  for (const auto &h : initial) {
+    work.push_back({h, mainSourceAbsPath});
+  }
   std::set<std::string> processed;
   size_t total = initial.size();
   size_t current = 0;
 
   while (!work.empty()) {
-    std::string hdr = work.back();
+    auto [hdr, parentPath] = work.back();
     work.pop_back();
     if (processed.count(hdr)) {
       outs() << sHipify << sWarning
@@ -212,13 +215,13 @@ bool hipifyLocalHeaders(const std::string &mainSourceAbsPath,
 
     std::string hipOut = hdr + ".hip";
     std::vector<std::string> precedingIncludes;
-    collectPrecedingIncludes(mainSourceAbsPath, hdr, precedingIncludes);
+    collectPrecedingIncludes(parentPath, hdr, precedingIncludes);
 
     outs() << "\n" << sHipify << "Hipifying local header [" << current
            << "/" << total << "]: " << sys::path::filename(hdr) << "\n";
 
     bool ok = hipifySingleSource(hdr, hipOut, compDB, OptionsParserPtr,
-                                  hipify_exe, mainSourceAbsPath, false,
+                                  hipify_exe, parentPath, false,
                                   precedingIncludes);
 
     if (!ok) {
@@ -240,7 +243,7 @@ bool hipifyLocalHeaders(const std::string &mainSourceAbsPath,
           std::string abs;
           if (resolveLocalIncludeInternal(hdr, rel, abs) &&
               !processed.count(abs)) {
-            work.push_back(abs);
+            work.push_back({abs, hdr});
             newHeaders.push_back(abs);
           }
         }

--- a/src/LocalHeader.cpp
+++ b/src/LocalHeader.cpp
@@ -1,3 +1,25 @@
+/*
+Copyright (c) 2026 - present Advanced Micro Devices, Inc. All rights reserved.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+*/
+
 #include "LocalHeader.h"
 #include "LLVMCompat.h"
 

--- a/src/LocalHeader.cpp
+++ b/src/LocalHeader.cpp
@@ -1,4 +1,5 @@
 #include "LocalHeader.h"
+#include "LLVMCompat.h"
 
 #include <sstream>
 #include <regex>
@@ -10,8 +11,6 @@
 #include "llvm/Support/Path.h"
 #include "llvm/Support/MemoryBuffer.h"
 #include "llvm/Support/raw_ostream.h"
-
-#include "LLVMCompat.h"
 
 using namespace clang;
 using namespace clang::tooling;
@@ -46,6 +45,9 @@ namespace {
   static const std::regex LocalIncludeRe(
       R"(^\s*#\s*include\s*\"([^\"\n]+)\"\s*(?://.*)?$)", std::regex::ECMAScript);
 
+  static const std::regex SystemIncludeRe(
+      R"(^\s*#\s*include\s*<([^>\n]+)>)", std::regex::ECMAScript);
+
   bool readFile(const std::string &path, std::string &out) {
     auto MBOrErr = llvm::MemoryBuffer::getFile(path);
     if (!MBOrErr) return false;
@@ -67,7 +69,41 @@ namespace {
     }
     return false;
   }
-} 
+
+  bool collectPrecedingIncludes(const std::string &mainSourceAbspath,
+                                const std::string &targetHeaderAbspath,
+                                std::vector<std::string> &outIncludes) {
+    std::string mainSourceContent;
+    if (!readFile(mainSourceAbspath, mainSourceContent)) {
+      errs() << sHipify << sError << "Cannot read source files: "
+            << mainSourceAbspath << "\n";
+      return false;
+    }
+
+    std::string targetFileName = std::string(sys::path::filename(targetHeaderAbspath));
+    std::istringstream iss(mainSourceContent);
+    std::string line;
+    std::smatch m;
+
+    while (std::getline(iss, line)) {
+      if (std::regex_match(line, m, LocalIncludeRe)) {
+        std::string quotedName = m[1].str();
+        std::string quotedFileName = std::string(sys::path::filename(quotedName));
+        if (quotedFileName == targetFileName)
+          break;
+        std::string absPath;
+        if (resolveLocalIncludeInternal(mainSourceAbspath, quotedName, absPath))
+          outIncludes.push_back(absPath);
+      }
+
+      if (std::regex_search(line, m, SystemIncludeRe)) {
+        outIncludes.push_back(m[1].str());
+      }
+    }
+
+    return true;
+  }
+}
 
 bool resolveLocalInclude(const std::string &mainSourceAbsPath,
                          const std::string &includeToken,
@@ -116,52 +152,87 @@ bool hipifyLocalHeaders(const std::string &mainSourceAbsPath,
   }
   
   if (initial.empty()) {
-    outs() << sHipify << "No local headers detected in " << mainSourceAbsPath << "\n";
+    outs() << "\n" << sHipify << "No local headers detected in "
+           << sys::path::filename(mainSourceAbsPath) << "\n";
     return true;
+  }
+
+  outs() << "\n" << sHipify << "Local headers found: " << initial.size()
+         << " in " << sys::path::filename(mainSourceAbsPath) << "\n";
+  for (size_t i = 0; i < initial.size(); ++i) {
+    outs() << (i + 1) << "/" << initial.size()
+           << ": " << sys::path::filename(initial[i]) << "\n";
   }
 
   std::vector<std::string> work(initial.begin(), initial.end());
   std::set<std::string> processed;
+  size_t total = initial.size();
+  size_t current = 0;
 
   while (!work.empty()) {
     std::string hdr = work.back();
     work.pop_back();
     if (processed.count(hdr)) {
-      errs() << sHipify << sWarning << "Duplicate local header reference ignored: " << hdr << "\n";
+      outs() << sHipify << sWarning
+             << "Duplicate local header reference ignored: "
+             << sys::path::filename(hdr) << "\n";
       continue;
     }
     processed.insert(hdr);
+    ++current;
 
     std::string original;
     if (!readFile(hdr, original)) {
-      errs() << sHipify << sError << "Cannot read header: " << hdr << "\n";
+      errs() << "\n" << sHipify << sError
+             << "Cannot read header: " << sys::path::filename(hdr) << "\n";
       continue;
     }
 
     std::string hipOut = hdr + ".hip";
+    std::vector<std::string> precedingIncludes;
+    collectPrecedingIncludes(mainSourceAbsPath, hdr, precedingIncludes);
+
+    outs() << "\n" << sHipify << "Hipifying local header [" << current
+           << "/" << total << "]: " << sys::path::filename(hdr) << "\n";
+
     bool ok = hipifySingleSource(hdr, hipOut, compDB, OptionsParserPtr,
-                                  hipify_exe, mainSourceAbsPath, false);
+                                  hipify_exe, mainSourceAbsPath, false,
+                                  precedingIncludes);
 
     if (!ok) {
-      errs() << sHipify << sError << "Hipify failed for header: " << hdr << "\n";
+      errs() << "\n" << sHipify << sError
+             << "Hipify failed for header [" << current << "/" << total
+             << "]: " << sys::path::filename(hdr) << "\n";
       return false;
     }
+    outs() << sHipify << "Successfully hipified header file" << "\n";
 
     if (recursive) {
       std::smatch m;
       std::istringstream iss(original);
       std::string line;
+      std::vector<std::string> newHeaders;
       while (std::getline(iss, line)) {
         if (std::regex_match(line, m, LocalIncludeRe)) {
           std::string rel = m[1].str();
           std::string abs;
           if (resolveLocalIncludeInternal(hdr, rel, abs) &&
-              !processed.count(abs))
+              !processed.count(abs)) {
             work.push_back(abs);
+            newHeaders.push_back(abs);
+          }
         }
+      }
+      if (!newHeaders.empty()) {
+        total += newHeaders.size();
+        outs() << sHipify << "  Recursive: found " << newHeaders.size()
+               << " additional local header(s) in "
+               << sys::path::filename(hdr) << "\n";
       }
     }
   }
 
+  outs() << "\n" << sHipify << "Local header hipification complete: "
+         << processed.size() << " header(s) processed.\n";
   return true;
 }

--- a/src/LocalHeader.cpp
+++ b/src/LocalHeader.cpp
@@ -24,15 +24,17 @@ THE SOFTWARE.
 #include "LLVMCompat.h"
 
 #include <memory>
-#include <set>
+#include <string>
 #include <vector>
 
+#include "clang/Basic/SourceManager.h"
 #include "clang/Frontend/CompilerInstance.h"
 #include "clang/Frontend/FrontendActions.h"
 #include "clang/Lex/PPCallbacks.h"
 #include "clang/Lex/Preprocessor.h"
 #include "clang/Tooling/CompilationDatabase.h"
 #include "clang/Tooling/Tooling.h"
+#include "llvm/ADT/StringSet.h"
 #include "llvm/Support/Path.h"
 #include "llvm/Support/raw_ostream.h"
 
@@ -43,79 +45,97 @@ using namespace std;
 
 namespace {
 
+std::string getFilePathForID(const clang::SourceManager &SM,
+                             clang::FileID FID) {
+  const clang::FileEntry *FE = SM.getFileEntryForID(FID);
+  if (!FE)
+    return std::string();
+  StringRef RealPath = FE->tryGetRealPathName();
+  if (!RealPath.empty())
+    return RealPath.str();
+  return SM.getFilename(SM.getLocForStartOfFile(FID)).str();
+}
+
+// Records every `#include` of a translation unit, except those issued from a
+// system header or from the command line.
 class IncludeCollectorCallbacks : public clang::PPCallbacks {
   const clang::SourceManager &SM;
   std::vector<IncludeEntry> &Entries;
 
 public:
   IncludeCollectorCallbacks(const clang::SourceManager &SM,
-                            std::vector<IncludeEntry> &entries)
-      : SM(SM), Entries(entries) {}
+                            std::vector<IncludeEntry> &Entries)
+      : SM(SM), Entries(Entries) {}
 
-  void InclusionDirective(clang::SourceLocation hash_loc,
-                          const clang::Token &include_token,
-                          StringRef file_name, bool is_angled,
-                          clang::CharSourceRange filename_range,
+  void InclusionDirective(clang::SourceLocation HashLoc, const clang::Token &,
+                          StringRef FileName, bool IsAngled,
+                          clang::CharSourceRange,
 #if LLVM_VERSION_MAJOR < 15
-                          const clang::FileEntry *file,
+                          const clang::FileEntry *File,
 #elif LLVM_VERSION_MAJOR == 15
-                          Optional<clang::FileEntryRef> file,
+                          Optional<clang::FileEntryRef> File,
 #else
-                          clang::OptionalFileEntryRef file,
+                          clang::OptionalFileEntryRef File,
 #endif
-                          StringRef search_path, StringRef relative_path,
+                          StringRef, StringRef,
 #if LLVM_VERSION_MAJOR < 19
-                          const clang::Module *SuggestedModule
+                          const clang::Module *
 #else
-                          const clang::Module *SuggestedModule,
-                          bool ModuleImported
+                          const clang::Module *, bool
 #endif
 #if LLVM_VERSION_MAJOR > 6
                           ,
                           clang::SrcMgr::CharacteristicKind FileType
 #endif
                           ) override {
-    if (!SM.isWrittenInMainFile(hash_loc))
+    const clang::FileID IncluderID = SM.getFileID(HashLoc);
+    std::string IncluderPath = getFilePathForID(SM, IncluderID);
+    if (IncluderPath.empty() || SM.isInSystemHeader(HashLoc))
       return;
 
-    IncludeEntry entry;
-    entry.fileName = file_name.str();
-    entry.isAngled = is_angled;
+    IncludeEntry Entry;
+    Entry.fileName = FileName.str();
+    Entry.isAngled = IsAngled;
+    Entry.includerPath = std::move(IncluderPath);
+    Entry.isFromMainFile = IncluderID == SM.getMainFileID();
+#if LLVM_VERSION_MAJOR > 6
+    Entry.isSystem = FileType != clang::SrcMgr::C_User;
+#endif
 
-    if (file) {
+    if (File) {
 #if LLVM_VERSION_MAJOR < 15
-      entry.resolvedPath = file->tryGetRealPathName().str();
-      if (entry.resolvedPath.empty())
-        entry.resolvedPath = file->getName().str();
+      Entry.resolvedPath = File->tryGetRealPathName().str();
+      if (Entry.resolvedPath.empty())
+        Entry.resolvedPath = File->getName().str();
 #else
-      entry.resolvedPath = file->getFileEntry().tryGetRealPathName().str();
-      if (entry.resolvedPath.empty())
-        entry.resolvedPath = file->getName().str();
+      Entry.resolvedPath = File->getFileEntry().tryGetRealPathName().str();
+      if (Entry.resolvedPath.empty())
+        Entry.resolvedPath = File->getName().str();
 #endif
     }
 
-    Entries.push_back(std::move(entry));
+    Entries.push_back(std::move(Entry));
   }
 };
 
-class IncludeCollectorAction : public clang::PreprocessorFrontendAction {
+// PreprocessOnlyAction supplies the lexing loop and IgnorePragmas().
+class IncludeCollectorAction : public clang::PreprocessOnlyAction {
   std::vector<IncludeEntry> &Entries;
 
 public:
-  explicit IncludeCollectorAction(std::vector<IncludeEntry> &entries)
-      : Entries(entries) {}
+  explicit IncludeCollectorAction(std::vector<IncludeEntry> &Entries)
+      : Entries(Entries) {}
 
-  void ExecuteAction() override {
-    clang::CompilerInstance &CI = getCompilerInstance();
-    clang::Preprocessor &PP = CI.getPreprocessor();
-    PP.addPPCallbacks(std::make_unique<IncludeCollectorCallbacks>(
-        CI.getSourceManager(), Entries));
-
-    PP.EnterMainSourceFile();
-    clang::Token Tok;
-    do {
-      PP.Lex(Tok);
-    } while (Tok.isNot(clang::tok::eof));
+protected:
+#if LLVM_VERSION_MAJOR < 5
+  bool BeginSourceFileAction(clang::CompilerInstance &CI, StringRef) override {
+#else
+  bool BeginSourceFileAction(clang::CompilerInstance &CI) override {
+#endif
+    CI.getPreprocessor().addPPCallbacks(
+        std::make_unique<IncludeCollectorCallbacks>(CI.getSourceManager(),
+                                                    Entries));
+    return true;
   }
 };
 
@@ -137,6 +157,49 @@ public:
 #endif
 };
 
+// Returns entries.size() when headerPath was never included.
+size_t findFirstInclusion(const std::vector<IncludeEntry> &entries,
+                          StringRef headerPath) {
+  size_t i = 0;
+  for (; i < entries.size(); ++i)
+    if (entries[i].resolvedPath == headerPath)
+      break;
+  return i;
+}
+
+// Files to `-include` in front of headerPath so that a header which is not
+// self-contained still sees what its ancestors included before it.
+std::vector<std::string>
+buildIncludeContext(const std::vector<IncludeEntry> &entries,
+                    StringRef headerPath) {
+  const size_t pos = findFirstInclusion(entries, headerPath);
+  if (pos == entries.size())
+    return std::vector<std::string>();
+
+  StringSet<> ancestors;
+  std::string file = entries[pos].includerPath;
+  while (!file.empty() && ancestors.insert(file).second) {
+    const size_t idx = findFirstInclusion(entries, file);
+    file = idx == entries.size() ? std::string() : entries[idx].includerPath;
+  }
+
+  std::vector<std::string> context;
+  StringSet<> seen;
+  for (size_t i = 0; i < pos; ++i) {
+    const IncludeEntry &e = entries[i];
+    // An ancestor would re-include headerPath, whose guard then empties the
+    // copy being hipified.
+    if (!ancestors.count(e.includerPath) || ancestors.count(e.resolvedPath))
+      continue;
+    // System headers are injected as spelled, to be found via the search paths.
+    std::string arg = e.isSystem ? e.fileName : e.resolvedPath;
+    if (arg.empty() || !seen.insert(arg).second)
+      continue;
+    context.push_back(std::move(arg));
+  }
+  return context;
+}
+
 } // namespace
 
 bool appendArgumentsAdjusters(ct::RefactoringTool &Tool,
@@ -147,134 +210,74 @@ bool collectIncludeTree(const std::string &srcPath,
                         const ct::CompilationDatabase *compDB,
                         ct::CommonOptionsParser *OptionsParserPtr,
                         const char *hipify_exe,
-                        const std::string &mainContextPath,
                         std::vector<IncludeEntry> &outEntries) {
   outEntries.clear();
 
-  const ct::CompilationDatabase &baseDB =
-      compDB ? *compDB : OptionsParserPtr->getCompilations();
+  ct::RefactoringTool Tool(
+      compDB ? *compDB : OptionsParserPtr->getCompilations(), {srcPath});
 
-  // If srcPath has no entry in the compilation database, fall back to a
-  // FixedCompilationDatabase rooted at the mainContextPath's directory so that
-  // the tool doesn't skip the file.
-  std::vector<ct::CompileCommand> cmds = baseDB.getCompileCommands(srcPath);
-  std::unique_ptr<ct::FixedCompilationDatabase> fallbackDB;
-  if (cmds.empty()) {
-    std::string dir = sys::path::parent_path(mainContextPath).str();
-    fallbackDB = std::make_unique<ct::FixedCompilationDatabase>(
-        dir, std::vector<std::string>());
-  }
-
-  ct::RefactoringTool Tool(fallbackDB ? *fallbackDB : baseDB, {srcPath});
-
-  if (!appendArgumentsAdjusters(Tool, mainContextPath, hipify_exe)) {
+  if (!appendArgumentsAdjusters(Tool, srcPath, hipify_exe)) {
     return false;
   }
 
   IncludeCollectorActionFactory factory(outEntries);
-  Tool.run(&factory);
-  return true;
-}
-
-bool collectLocalQuotedIncludes(const std::string &mainSourceAbsPath,
-                                const ct::CompilationDatabase *compDB,
-                                ct::CommonOptionsParser *OptionsParserPtr,
-                                const char *hipify_exe,
-                                std::vector<std::string> &outHeaders) {
-  std::vector<IncludeEntry> entries;
-  if (!collectIncludeTree(mainSourceAbsPath, compDB, OptionsParserPtr,
-                          hipify_exe, mainSourceAbsPath, entries)) {
-    errs() << "\n"
-           << sHipify << sError
-           << "Failed to collect includes from: " << mainSourceAbsPath << "\n";
-    return false;
-  }
-
-  std::set<std::string> uniq;
-  for (const auto &e : entries) {
-    if (!e.isAngled && !e.resolvedPath.empty())
-      uniq.insert(e.resolvedPath);
-  }
-  outHeaders.assign(uniq.begin(), uniq.end());
-  return true;
+  return Tool.run(&factory) == 0;
 }
 
 bool hipifyLocalHeaders(const std::string &mainSourceAbsPath,
                         const ct::CompilationDatabase *compDB,
                         ct::CommonOptionsParser *OptionsParserPtr,
                         const char *hipify_exe, bool recursive) {
-
-  std::vector<std::string> initial;
-  if (!collectLocalQuotedIncludes(mainSourceAbsPath, compDB, OptionsParserPtr,
-                                  hipify_exe, initial)) {
+  std::vector<IncludeEntry> entries;
+  if (!collectIncludeTree(mainSourceAbsPath, compDB, OptionsParserPtr,
+                          hipify_exe, entries)) {
+    errs() << "\n"
+           << sHipify << sError
+           << "Failed to collect includes from: " << mainSourceAbsPath << "\n";
     return false;
   }
 
-  if (initial.empty()) {
+  // The single run already walked the whole tree; recursion is just the
+  // unfiltered result. Include guards make each path appear at most once.
+  std::vector<std::string> headers;
+  StringSet<> seen;
+  for (const IncludeEntry &e : entries) {
+    if (e.isAngled || e.isSystem || e.resolvedPath.empty())
+      continue;
+    if (!recursive && !e.isFromMainFile)
+      continue;
+    if (seen.insert(e.resolvedPath).second)
+      headers.push_back(e.resolvedPath);
+  }
+
+  if (headers.empty()) {
     outs() << "\n" << sHipify << "No local headers detected in "
            << sys::path::filename(mainSourceAbsPath) << "\n";
     return true;
   }
 
-  outs() << "\n" << sHipify << "Local headers found: " << initial.size()
+  outs() << "\n" << sHipify << "Local headers found: " << headers.size()
          << " in " << sys::path::filename(mainSourceAbsPath) << "\n";
-  for (size_t i = 0; i < initial.size(); ++i) {
-    outs() << (i + 1) << "/" << initial.size()
-           << ": " << sys::path::filename(initial[i]) << "\n";
+  for (size_t i = 0; i < headers.size(); ++i) {
+    outs() << (i + 1) << "/" << headers.size() << ": "
+           << sys::path::filename(headers[i]) << "\n";
   }
 
-  std::vector<std::string> work(initial.begin(), initial.end());
-  std::set<std::string> processed;
-  std::set<std::string> queued(initial.begin(), initial.end());
-  size_t total = initial.size();
-  size_t current = 0;
-
-  while (!work.empty()) {
-    std::string hdr = work.back();
-    work.pop_back();
-    if (processed.count(hdr)) {
-      continue;
-    }
-    processed.insert(hdr);
-    ++current;
-
+  for (size_t i = 0; i < headers.size(); ++i) {
+    const std::string &hdr = headers[i];
     std::string hipOut = hdr + ".hip";
-    bool ok = hipifySingleSource(hdr, hipOut, compDB, OptionsParserPtr,
-                                 hipify_exe, mainSourceAbsPath, false);
-
-    if (!ok) {
-      errs() << "\n" << sHipify << sError
-             << "Hipify failed for header [" << current << "/" << total
-             << "]: " << sys::path::filename(hdr) << "\n";
+    if (!hipifySingleSource(hdr, hipOut, compDB, OptionsParserPtr, hipify_exe,
+                            mainSourceAbsPath, false,
+                            buildIncludeContext(entries, hdr))) {
+      errs() << "\n" << sHipify << sError << "Hipify failed for header ["
+             << (i + 1) << "/" << headers.size() << "]: "
+             << sys::path::filename(hdr) << "\n";
       return false;
     }
     outs() << sHipify << "Successfully hipified header file" << "\n";
-
-    if (recursive) {
-      std::vector<IncludeEntry> childEntries;
-      if (collectIncludeTree(hdr, compDB, OptionsParserPtr, hipify_exe,
-                             mainSourceAbsPath, childEntries)) {
-        std::vector<std::string> newHeaders;
-        for (const auto &e : childEntries) {
-          if (!e.isAngled && !e.resolvedPath.empty() &&
-              !processed.count(e.resolvedPath) &&
-              !queued.count(e.resolvedPath)) {
-            newHeaders.push_back(e.resolvedPath);
-            work.push_back(e.resolvedPath);
-            queued.insert(e.resolvedPath);
-          }
-        }
-        if (!newHeaders.empty()) {
-          total += newHeaders.size();
-          outs() << sHipify << "  Recursive: found " << newHeaders.size()
-                 << " additional local header(s) in "
-                 << sys::path::filename(hdr) << "\n";
-        }
-      }
-    }
   }
 
   outs() << "\n" << sHipify << "Local header hipification complete: "
-         << processed.size() << " header(s) processed.\n";
+         << headers.size() << " header(s) processed.\n";
   return true;
 }

--- a/src/LocalHeader.cpp
+++ b/src/LocalHeader.cpp
@@ -91,38 +91,62 @@ namespace {
     }
     return false;
   }
-
-  bool collectPrecedingIncludes(const std::string &mainSourceAbspath,
-                                const std::string &targetHeaderAbspath,
-                                std::vector<std::string> &outIncludes) {
-    std::string mainSourceContent;
-    if (!readFile(mainSourceAbspath, mainSourceContent)) {
-      errs() << sHipify << sError << "Cannot read source files: "
-            << mainSourceAbspath << "\n";
+  
+  static bool collectIncludesBefore(const std::string &filePath,
+                                    const std::string &stopAtAbsPath,
+                                    bool collectLocal,
+                                    std::set<std::string> &seen,
+                                    std::vector<std::string> &outIncludes) {
+    std::string content;
+    if (!readFile(filePath, content))
       return false;
-    }
-
-    std::istringstream iss(mainSourceContent);
+    
+    std::istringstream iss(content);
     std::string line;
     std::smatch m;
 
     while (std::getline(iss, line)) {
       if (std::regex_search(line, m, LocalIncludeRe)) {
-        std::string quotedName = m[1].str();
-        std::string absPath;
-        if (resolveLocalIncludeInternal(mainSourceAbspath, quotedName, absPath)) {
-          if (absPath == targetHeaderAbspath)
+        std::string abspath;
+        if (resolveLocalIncludeInternal(filePath, m[1].str(), abspath)) {
+          if (abspath == stopAtAbsPath)
             break;
-          outIncludes.push_back(absPath);
+          if (collectLocal && seen.insert(abspath).second)
+            outIncludes.push_back(abspath);
         }
       }
-
       if (std::regex_search(line, m, SystemIncludeRe)) {
-        outIncludes.push_back(m[1].str());
+        std::string sysInclude = m[1].str();
+        if (seen.insert(sysInclude).second)
+          outIncludes.push_back(sysInclude);
       }
     }
-
     return true;
+  }
+
+  bool collectPrecedingIncludes(const std::string &mainSourceAbspath,
+                                const std::string &targetHeaderAbspath,
+                                std::vector<std::string> &outIncludes) {
+
+    std::set<std::string> seen;
+
+    if (!collectIncludesBefore(mainSourceAbspath, targetHeaderAbspath, true, seen, outIncludes)) {
+      errs() << sHipify << sError << "Cannot read source files: "
+             << mainSourceAbspath << "\n";
+      return false;
+    }
+    return true;
+  }
+
+  void collectAncestorSystemIncludes(
+      const std::vector<std::string> &ancestorChain,
+      std::vector<std::string> &outIncludes) {
+
+    std::set<std::string> seen(outIncludes.begin(), outIncludes.end());
+
+    for (size_t i = 1; i < ancestorChain.size(); ++i) {
+      collectIncludesBefore(ancestorChain[i], ancestorChain[i - 1], false, seen, outIncludes);
+    }
   }
 }
 
@@ -198,9 +222,9 @@ bool hipifyLocalHeaders(const std::string &mainSourceAbsPath,
            << ": " << sys::path::filename(initial[i]) << "\n";
   }
 
-  std::vector<std::pair<std::string, std::string>> work;
+  std::vector<std::pair<std::string, std::vector<std::string>>> work;
   for (const auto &h : initial) {
-    work.push_back({h, mainSourceAbsPath});
+    work.push_back({h, std::vector<std::string>{mainSourceAbsPath}});
   }
   std::set<std::string> processed;
   std::set<std::string> queued;
@@ -213,8 +237,9 @@ bool hipifyLocalHeaders(const std::string &mainSourceAbsPath,
 
   while (!work.empty()) {
     std::string hdr = work.back().first;
-    std::string parentPath = work.back().second;
+    std::vector<std::string> ancestorChain = work.back().second;
     work.pop_back();
+    std::string parentPath = ancestorChain[0];
     if (processed.count(hdr)) {
       outs() << sHipify << sWarning
              << "Duplicate local header reference ignored: "
@@ -234,7 +259,7 @@ bool hipifyLocalHeaders(const std::string &mainSourceAbsPath,
     std::string hipOut = hdr + ".hip";
     std::vector<std::string> precedingIncludes;
     collectPrecedingIncludes(parentPath, hdr, precedingIncludes);
-
+    collectAncestorSystemIncludes(ancestorChain, precedingIncludes);
     outs() << "\n" << sHipify << "Hipifying local header [" << current
            << "/" << total << "]: " << sys::path::filename(hdr) << "\n";
 
@@ -263,7 +288,10 @@ bool hipifyLocalHeaders(const std::string &mainSourceAbsPath,
           if (resolveLocalIncludeInternal(hdr, rel, abs) &&
               !processed.count(abs) && !queued.count(abs)) {
             queued.insert(abs);
-            work.push_back({abs, hdr});
+            std::vector<std::string> childChain;
+            childChain.push_back(hdr);
+            childChain.insert(childChain.end(), ancestorChain.begin(), ancestorChain.end());
+            work.push_back({abs, childChain});
             newHeaders.push_back(abs);
           }
         }

--- a/src/LocalHeader.cpp
+++ b/src/LocalHeader.cpp
@@ -102,7 +102,6 @@ namespace {
       return false;
     }
 
-    std::string targetFileName = std::string(sys::path::filename(targetHeaderAbspath));
     std::istringstream iss(mainSourceContent);
     std::string line;
     std::smatch m;
@@ -125,6 +124,19 @@ namespace {
 
     return true;
   }
+}
+
+static std::string
+resolveCompileContext(const std::string &parentPath,
+                      const std::string &mainSourceAbsPath,
+                      const clang::tooling::CompilationDatabase *compDB) {
+  if (!compDB)
+    return mainSourceAbsPath;
+
+  if (!compDB->getCompileCommands(parentPath).empty())
+    return parentPath;
+
+  return mainSourceAbsPath;
 }
 
 bool resolveLocalInclude(const std::string &mainSourceAbsPath,
@@ -225,9 +237,10 @@ bool hipifyLocalHeaders(const std::string &mainSourceAbsPath,
     outs() << "\n" << sHipify << "Hipifying local header [" << current
            << "/" << total << "]: " << sys::path::filename(hdr) << "\n";
 
-    bool ok = hipifySingleSource(hdr, hipOut, compDB, OptionsParserPtr,
-                                  hipify_exe, parentPath, false,
-                                  precedingIncludes);
+    bool ok = hipifySingleSource(
+        hdr, hipOut, compDB, OptionsParserPtr, hipify_exe,
+        resolveCompileContext(parentPath, mainSourceAbsPath, compDB), false,
+        precedingIncludes);
 
     if (!ok) {
       errs() << "\n" << sHipify << sError

--- a/src/LocalHeader.cpp
+++ b/src/LocalHeader.cpp
@@ -23,15 +23,16 @@ THE SOFTWARE.
 #include "LocalHeader.h"
 #include "LLVMCompat.h"
 
-#include <sstream>
-#include <regex>
 #include <set>
 #include <vector>
-#include <system_error>
 
-#include "llvm/Support/FileSystem.h"
+#include "clang/Frontend/CompilerInstance.h"
+#include "clang/Frontend/FrontendActions.h"
+#include "clang/Lex/PPCallbacks.h"
+#include "clang/Lex/Preprocessor.h"
+#include "clang/Tooling/CompilationDatabase.h"
+#include "clang/Tooling/Tooling.h"
 #include "llvm/Support/Path.h"
-#include "llvm/Support/MemoryBuffer.h"
 #include "llvm/Support/raw_ostream.h"
 
 using namespace clang;
@@ -39,176 +40,187 @@ using namespace clang::tooling;
 using namespace llvm;
 using namespace std;
 
-static std::string normalizeSmallStringPath(SmallString<256> &p) {
-  llvm::sys::path::remove_dots(p, true);
-
-  SmallString<256> realBuf;
-  std::error_code ec = llvm::sys::fs::real_path(p, realBuf);
-  if (!ec) {
-    return std::string(realBuf.str());
-  }
-
-  return std::string(p.str());
-}
-
-static bool pathExists(const std::string &p) {
-  SmallString<256> in(p.begin(), p.end());
-
-  SmallString<256> realBuf;
-  std::error_code ec = llvm::sys::fs::real_path(in, realBuf);
-  if (!ec) return true;
-
-  SmallString<256> norm = in;
-  llvm::sys::path::remove_dots(norm, true);
-  return llvm::sys::fs::exists(norm);
-}
-
 namespace {
-  static const std::regex LocalIncludeRe
-      (R"re(^\s*#\s*include\s*"([^"\n]+)")re", std::regex::ECMAScript);
 
-  static const std::regex SystemIncludeRe(
-      R"(^\s*#\s*include\s*<([^>\n]+)>)", std::regex::ECMAScript);
+class IncludeCollectorCallbacks : public clang::PPCallbacks {
+  const clang::SourceManager &SM;
+  std::vector<IncludeEntry> &Entries;
 
-  bool readFile(const std::string &path, std::string &out) {
-    auto MBOrErr = llvm::MemoryBuffer::getFile(path);
-    if (!MBOrErr) return false;
-    out = MBOrErr->get()->getBuffer().str();
-    return true;
+public:
+  IncludeCollectorCallbacks(const clang::SourceManager &SM,
+                            std::vector<IncludeEntry> &entries)
+      : SM(SM), Entries(entries) {}
+
+  void InclusionDirective(clang::SourceLocation hash_loc,
+                          const clang::Token &include_token,
+                          StringRef file_name, bool is_angled,
+                          clang::CharSourceRange filename_range,
+#if LLVM_VERSION_MAJOR < 15
+                          const clang::FileEntry *file,
+#elif LLVM_VERSION_MAJOR == 15
+                          Optional<clang::FileEntryRef> file,
+#else
+                          clang::OptionalFileEntryRef file,
+#endif
+                          StringRef search_path, StringRef relative_path,
+#if LLVM_VERSION_MAJOR < 19
+                          const clang::Module *SuggestedModule
+#else
+                          const clang::Module *SuggestedModule,
+                          bool ModuleImported
+#endif
+#if LLVM_VERSION_MAJOR > 6
+                          ,
+                          clang::SrcMgr::CharacteristicKind FileType
+#endif
+                          ) override {
+    if (!SM.isWrittenInMainFile(hash_loc))
+      return;
+
+    IncludeEntry entry;
+    entry.fileName = file_name.str();
+    entry.isAngled = is_angled;
+
+    if (file) {
+#if LLVM_VERSION_MAJOR < 15
+      entry.resolvedPath = file->tryGetRealPathName().str();
+      if (entry.resolvedPath.empty())
+        entry.resolvedPath = file->getName().str();
+#else
+      entry.resolvedPath = file->getFileEntry().tryGetRealPathName().str();
+      if (entry.resolvedPath.empty())
+        entry.resolvedPath = file->getName().str();
+#endif
+    }
+
+    Entries.push_back(std::move(entry));
+  }
+};
+
+class IncludeCollectorAction : public clang::PreprocessorFrontendAction {
+  std::vector<IncludeEntry> &Entries;
+
+public:
+  explicit IncludeCollectorAction(std::vector<IncludeEntry> &entries)
+      : Entries(entries) {}
+
+  void ExecuteAction() override {
+    clang::CompilerInstance &CI = getCompilerInstance();
+    clang::Preprocessor &PP = CI.getPreprocessor();
+    PP.addPPCallbacks(std::make_unique<IncludeCollectorCallbacks>(
+        CI.getSourceManager(), Entries));
+
+    PP.EnterMainSourceFile();
+    clang::Token Tok;
+    do {
+      PP.Lex(Tok);
+    } while (Tok.isNot(clang::tok::eof));
+  }
+};
+
+class IncludeCollectorActionFactory : public FrontendActionFactory {
+  std::vector<IncludeEntry> &Entries;
+
+public:
+  explicit IncludeCollectorActionFactory(std::vector<IncludeEntry> &entries)
+      : Entries(entries) {}
+
+#if LLVM_VERSION_MAJOR >= 10
+  std::unique_ptr<clang::FrontendAction> create() override {
+    return std::make_unique<IncludeCollectorAction>(Entries);
+  }
+#else
+  clang::FrontendAction *create() override {
+    return new IncludeCollectorAction(Entries);
+  }
+#endif
+};
+
+} // namespace
+
+bool collectIncludeTree(const std::string &srcPath,
+                        const ct::CompilationDatabase *compDB,
+                        ct::CommonOptionsParser *OptionsParserPtr,
+                        const char *hipify_exe,
+                        const std::string &mainContextPath,
+                        std::vector<IncludeEntry> &outEntries) {
+  outEntries.clear();
+
+  const ct::CompilationDatabase &baseDB =
+      compDB ? *compDB : OptionsParserPtr->getCompilations();
+
+  // If srcPath has no entry in the compilation database, fall back to a
+  // FixedCompilationDatabase rooted at the mainContextPath's directory so that
+  // the tool doesn't skip the file.
+  std::vector<ct::CompileCommand> cmds = baseDB.getCompileCommands(srcPath);
+  std::unique_ptr<ct::FixedCompilationDatabase> fallbackDB;
+  if (cmds.empty()) {
+    std::string dir = sys::path::parent_path(mainContextPath).str();
+    fallbackDB = std::make_unique<ct::FixedCompilationDatabase>(
+        dir, std::vector<std::string>());
   }
 
-  bool resolveLocalIncludeInternal(const std::string &mainSourceAbsPath,
-                                  const std::string &includeTok,
-                                  std::string &outAbs) {
-    SmallString<256> base(mainSourceAbsPath);
-    sys::path::remove_filename(base);
-    SmallString<256> candidate(base);
-    sys::path::append(candidate, includeTok);
-    sys::path::remove_dots(candidate, true);
-    if (pathExists(std::string(candidate.str()))) {
-      outAbs = normalizeSmallStringPath(candidate);
-      return true;
-    }
+  ct::RefactoringTool Tool(fallbackDB ? *fallbackDB : baseDB, {srcPath});
+
+  if (!appendArgumentsAdjusters(Tool, mainContextPath, hipify_exe)) {
     return false;
   }
-  
-  static bool collectIncludesBefore(const std::string &filePath,
-                                    const std::string &stopAtAbsPath,
-                                    bool collectLocal,
-                                    std::set<std::string> &seen,
-                                    std::vector<std::string> &outIncludes) {
-    std::string content;
-    if (!readFile(filePath, content))
-      return false;
-    
-    std::istringstream iss(content);
-    std::string line;
-    std::smatch m;
 
-    while (std::getline(iss, line)) {
-      if (std::regex_search(line, m, LocalIncludeRe)) {
-        std::string abspath;
-        if (resolveLocalIncludeInternal(filePath, m[1].str(), abspath)) {
-          if (abspath == stopAtAbsPath)
-            break;
-          if (collectLocal && seen.insert(abspath).second)
-            outIncludes.push_back(abspath);
+  // Strip the implicit CUDA header that appendArgumentsAdjusters adds —
+  // not needed for include scanning and would pollute the results.
+  Tool.appendArgumentsAdjuster(
+      [](const ct::CommandLineArguments &Args, StringRef) {
+        ct::CommandLineArguments filtered;
+        for (size_t i = 0; i < Args.size(); ++i) {
+          if (Args[i] == "-include" && i + 1 < Args.size() &&
+              Args[i + 1] == "cuda_runtime.h") {
+            ++i;
+            continue;
+          }
+          filtered.push_back(Args[i]);
         }
-      }
-      if (std::regex_search(line, m, SystemIncludeRe)) {
-        std::string sysInclude = m[1].str();
-        if (seen.insert(sysInclude).second)
-          outIncludes.push_back(sysInclude);
-      }
-    }
-    return true;
-  }
+        return filtered;
+      });
 
-  bool collectPrecedingIncludes(const std::string &mainSourceAbspath,
-                                const std::string &targetHeaderAbspath,
-                                std::vector<std::string> &outIncludes) {
-
-    std::set<std::string> seen;
-
-    if (!collectIncludesBefore(mainSourceAbspath, targetHeaderAbspath, true, seen, outIncludes)) {
-      errs() << sHipify << sError << "Cannot read source files: "
-             << mainSourceAbspath << "\n";
-      return false;
-    }
-    return true;
-  }
-
-  void collectAncestorSystemIncludes(
-      const std::vector<std::string> &ancestorChain,
-      std::vector<std::string> &outIncludes) {
-
-    std::set<std::string> seen(outIncludes.begin(), outIncludes.end());
-
-    for (size_t i = 1; i < ancestorChain.size(); ++i) {
-      collectIncludesBefore(ancestorChain[i], ancestorChain[i - 1], false, seen, outIncludes);
-    }
-  }
-}
-
-static std::string
-resolveCompileContext(const std::string &parentPath,
-                      const std::string &mainSourceAbsPath,
-                      const clang::tooling::CompilationDatabase *compDB) {
-  if (!compDB)
-    return mainSourceAbsPath;
-
-  if (!compDB->getCompileCommands(parentPath).empty())
-    return parentPath;
-
-  return mainSourceAbsPath;
-}
-
-bool resolveLocalInclude(const std::string &mainSourceAbsPath,
-                         const std::string &includeToken,
-                         std::string &outAbsPath) {
-  return resolveLocalIncludeInternal(mainSourceAbsPath, includeToken, outAbsPath);
+  IncludeCollectorActionFactory factory(outEntries);
+  Tool.run(&factory);
+  return true;
 }
 
 bool collectLocalQuotedIncludes(const std::string &mainSourceAbsPath,
+                                const ct::CompilationDatabase *compDB,
+                                ct::CommonOptionsParser *OptionsParserPtr,
+                                const char *hipify_exe,
                                 std::vector<std::string> &outHeaders) {
-  std::string content;
-  if (!readFile(mainSourceAbsPath, content)) {
-    errs() << "\n" << sHipify << sError << "Cannot read source file: " << mainSourceAbsPath << "\n";
+  std::vector<IncludeEntry> entries;
+  if (!collectIncludeTree(mainSourceAbsPath, compDB, OptionsParserPtr,
+                          hipify_exe, mainSourceAbsPath, entries)) {
+    errs() << "\n"
+           << sHipify << sError
+           << "Failed to collect includes from: " << mainSourceAbsPath << "\n";
     return false;
   }
 
   std::set<std::string> uniq;
-  std::smatch m;
-  std::istringstream iss(content);
-  std::string line;
-  while (std::getline(iss, line)) {
-    if (std::regex_search(line, m, LocalIncludeRe)) {
-      std::string rel = m[1].str();
-      std::string abs;
-      if (resolveLocalIncludeInternal(mainSourceAbsPath, rel, abs)){
-        uniq.insert(abs);
-      } else {
-        errs() << sHipify << sWarning
-               << "Missing local header referenced: \"" << rel
-               << "\" in " << mainSourceAbsPath << "\n";
-      }
-    }
+  for (const auto &e : entries) {
+    if (!e.isAngled && !e.resolvedPath.empty())
+      uniq.insert(e.resolvedPath);
   }
   outHeaders.assign(uniq.begin(), uniq.end());
   return true;
 }
 
 bool hipifyLocalHeaders(const std::string &mainSourceAbsPath,
-                             const ct::CompilationDatabase *compDB,
-                             ct::CommonOptionsParser *OptionsParserPtr,
-                             const char *hipify_exe,
-                             bool recursive) {
+                        const ct::CompilationDatabase *compDB,
+                        ct::CommonOptionsParser *OptionsParserPtr,
+                        const char *hipify_exe, bool recursive) {
 
   std::vector<std::string> initial;
-  if (!collectLocalQuotedIncludes(mainSourceAbsPath, initial)) {
+  if (!collectLocalQuotedIncludes(mainSourceAbsPath, compDB, OptionsParserPtr,
+                                  hipify_exe, initial)) {
     return false;
   }
-  
+
   if (initial.empty()) {
     outs() << "\n" << sHipify << "No local headers detected in "
            << sys::path::filename(mainSourceAbsPath) << "\n";
@@ -222,51 +234,24 @@ bool hipifyLocalHeaders(const std::string &mainSourceAbsPath,
            << ": " << sys::path::filename(initial[i]) << "\n";
   }
 
-  std::vector<std::pair<std::string, std::vector<std::string>>> work;
-  for (const auto &h : initial) {
-    work.push_back({h, std::vector<std::string>{mainSourceAbsPath}});
-  }
+  std::vector<std::string> work(initial.begin(), initial.end());
   std::set<std::string> processed;
-  std::set<std::string> queued;
+  std::set<std::string> queued(initial.begin(), initial.end());
   size_t total = initial.size();
   size_t current = 0;
 
-  for (const auto &h: initial) {
-    queued.insert(h);
-  }
-
   while (!work.empty()) {
-    std::string hdr = work.back().first;
-    std::vector<std::string> ancestorChain = work.back().second;
+    std::string hdr = work.back();
     work.pop_back();
-    std::string parentPath = ancestorChain[0];
     if (processed.count(hdr)) {
-      outs() << sHipify << sWarning
-             << "Duplicate local header reference ignored: "
-             << sys::path::filename(hdr) << "\n";
       continue;
     }
     processed.insert(hdr);
     ++current;
 
-    std::string original;
-    if (!readFile(hdr, original)) {
-      errs() << "\n" << sHipify << sError
-             << "Cannot read header: " << sys::path::filename(hdr) << "\n";
-      continue;
-    }
-
     std::string hipOut = hdr + ".hip";
-    std::vector<std::string> precedingIncludes;
-    collectPrecedingIncludes(parentPath, hdr, precedingIncludes);
-    collectAncestorSystemIncludes(ancestorChain, precedingIncludes);
-    outs() << "\n" << sHipify << "Hipifying local header [" << current
-           << "/" << total << "]: " << sys::path::filename(hdr) << "\n";
-
-    bool ok = hipifySingleSource(
-        hdr, hipOut, compDB, OptionsParserPtr, hipify_exe,
-        resolveCompileContext(parentPath, mainSourceAbsPath, compDB), false,
-        precedingIncludes);
+    bool ok = hipifySingleSource(hdr, hipOut, compDB, OptionsParserPtr,
+                                 hipify_exe, mainSourceAbsPath, false);
 
     if (!ok) {
       errs() << "\n" << sHipify << sError
@@ -277,30 +262,25 @@ bool hipifyLocalHeaders(const std::string &mainSourceAbsPath,
     outs() << sHipify << "Successfully hipified header file" << "\n";
 
     if (recursive) {
-      std::smatch m;
-      std::istringstream iss(original);
-      std::string line;
-      std::vector<std::string> newHeaders;
-      while (std::getline(iss, line)) {
-        if (std::regex_search(line, m, LocalIncludeRe)) {
-          std::string rel = m[1].str();
-          std::string abs;
-          if (resolveLocalIncludeInternal(hdr, rel, abs) &&
-              !processed.count(abs) && !queued.count(abs)) {
-            queued.insert(abs);
-            std::vector<std::string> childChain;
-            childChain.push_back(hdr);
-            childChain.insert(childChain.end(), ancestorChain.begin(), ancestorChain.end());
-            work.push_back({abs, childChain});
-            newHeaders.push_back(abs);
+      std::vector<IncludeEntry> childEntries;
+      if (collectIncludeTree(hdr, compDB, OptionsParserPtr, hipify_exe,
+                             mainSourceAbsPath, childEntries)) {
+        std::vector<std::string> newHeaders;
+        for (const auto &e : childEntries) {
+          if (!e.isAngled && !e.resolvedPath.empty() &&
+              !processed.count(e.resolvedPath) &&
+              !queued.count(e.resolvedPath)) {
+            newHeaders.push_back(e.resolvedPath);
+            work.push_back(e.resolvedPath);
+            queued.insert(e.resolvedPath);
           }
         }
-      }
-      if (!newHeaders.empty()) {
-        total += newHeaders.size();
-        outs() << sHipify << "  Recursive: found " << newHeaders.size()
-               << " additional local header(s) in "
-               << sys::path::filename(hdr) << "\n";
+        if (!newHeaders.empty()) {
+          total += newHeaders.size();
+          outs() << sHipify << "  Recursive: found " << newHeaders.size()
+                 << " additional local header(s) in "
+                 << sys::path::filename(hdr) << "\n";
+        }
       }
     }
   }

--- a/src/LocalHeader.cpp
+++ b/src/LocalHeader.cpp
@@ -64,8 +64,8 @@ static bool pathExists(const std::string &p) {
 }
 
 namespace {
-  static const std::regex LocalIncludeRe(
-      R"(^\s*#\s*include\s*\"([^\"\n]+)\"\s*(?://.*)?)", std::regex::ECMAScript);
+  static const std::regex LocalIncludeRe
+      (R"re(^\s*#\s*include\s*"([^"\n]+)")re", std::regex::ECMAScript);
 
   static const std::regex SystemIncludeRe(
       R"(^\s*#\s*include\s*<([^>\n]+)>)", std::regex::ECMAScript);
@@ -107,7 +107,7 @@ namespace {
     std::smatch m;
 
     while (std::getline(iss, line)) {
-      if (std::regex_match(line, m, LocalIncludeRe)) {
+      if (std::regex_search(line, m, LocalIncludeRe)) {
         std::string quotedName = m[1].str();
         std::string absPath;
         if (resolveLocalIncludeInternal(mainSourceAbspath, quotedName, absPath)) {
@@ -158,7 +158,7 @@ bool collectLocalQuotedIncludes(const std::string &mainSourceAbsPath,
   std::istringstream iss(content);
   std::string line;
   while (std::getline(iss, line)) {
-    if (std::regex_match(line, m, LocalIncludeRe)) {
+    if (std::regex_search(line, m, LocalIncludeRe)) {
       std::string rel = m[1].str();
       std::string abs;
       if (resolveLocalIncludeInternal(mainSourceAbsPath, rel, abs)){
@@ -212,7 +212,8 @@ bool hipifyLocalHeaders(const std::string &mainSourceAbsPath,
   }
 
   while (!work.empty()) {
-    auto [hdr, parentPath] = work.back();
+    std::string hdr = work.back().first;
+    std::string parentPath = work.back().second;
     work.pop_back();
     if (processed.count(hdr)) {
       outs() << sHipify << sWarning
@@ -256,7 +257,7 @@ bool hipifyLocalHeaders(const std::string &mainSourceAbsPath,
       std::string line;
       std::vector<std::string> newHeaders;
       while (std::getline(iss, line)) {
-        if (std::regex_match(line, m, LocalIncludeRe)) {
+        if (std::regex_search(line, m, LocalIncludeRe)) {
           std::string rel = m[1].str();
           std::string abs;
           if (resolveLocalIncludeInternal(hdr, rel, abs) &&

--- a/src/LocalHeader.cpp
+++ b/src/LocalHeader.cpp
@@ -65,7 +65,7 @@ static bool pathExists(const std::string &p) {
 
 namespace {
   static const std::regex LocalIncludeRe(
-      R"(^\s*#\s*include\s*\"([^\"\n]+)\"\s*(?://.*)?$)", std::regex::ECMAScript);
+      R"(^\s*#\s*include\s*\"([^\"\n]+)\"\s*(?://.*)?)", std::regex::ECMAScript);
 
   static const std::regex SystemIncludeRe(
       R"(^\s*#\s*include\s*<([^>\n]+)>)", std::regex::ECMAScript);
@@ -110,12 +110,12 @@ namespace {
     while (std::getline(iss, line)) {
       if (std::regex_match(line, m, LocalIncludeRe)) {
         std::string quotedName = m[1].str();
-        std::string quotedFileName = std::string(sys::path::filename(quotedName));
-        if (quotedFileName == targetFileName)
-          break;
         std::string absPath;
-        if (resolveLocalIncludeInternal(mainSourceAbspath, quotedName, absPath))
+        if (resolveLocalIncludeInternal(mainSourceAbspath, quotedName, absPath)) {
+          if (absPath == targetHeaderAbspath)
+            break;
           outIncludes.push_back(absPath);
+        }
       }
 
       if (std::regex_search(line, m, SystemIncludeRe)) {
@@ -191,8 +191,13 @@ bool hipifyLocalHeaders(const std::string &mainSourceAbsPath,
     work.push_back({h, mainSourceAbsPath});
   }
   std::set<std::string> processed;
+  std::set<std::string> queued;
   size_t total = initial.size();
   size_t current = 0;
+
+  for (const auto &h: initial) {
+    queued.insert(h);
+  }
 
   while (!work.empty()) {
     auto [hdr, parentPath] = work.back();
@@ -242,7 +247,8 @@ bool hipifyLocalHeaders(const std::string &mainSourceAbsPath,
           std::string rel = m[1].str();
           std::string abs;
           if (resolveLocalIncludeInternal(hdr, rel, abs) &&
-              !processed.count(abs)) {
+              !processed.count(abs) && !queued.count(abs)) {
+            queued.insert(abs);
             work.push_back({abs, hdr});
             newHeaders.push_back(abs);
           }

--- a/src/LocalHeader.cpp
+++ b/src/LocalHeader.cpp
@@ -23,6 +23,7 @@ THE SOFTWARE.
 #include "LocalHeader.h"
 #include "LLVMCompat.h"
 
+#include <memory>
 #include <set>
 #include <vector>
 
@@ -138,6 +139,10 @@ public:
 
 } // namespace
 
+bool appendArgumentsAdjusters(ct::RefactoringTool &Tool,
+                              const std::string &sSourceAbsPath,
+                              const char *hipify_exe);
+
 bool collectIncludeTree(const std::string &srcPath,
                         const ct::CompilationDatabase *compDB,
                         ct::CommonOptionsParser *OptionsParserPtr,
@@ -165,22 +170,6 @@ bool collectIncludeTree(const std::string &srcPath,
   if (!appendArgumentsAdjusters(Tool, mainContextPath, hipify_exe)) {
     return false;
   }
-
-  // Strip the implicit CUDA header that appendArgumentsAdjusters adds —
-  // not needed for include scanning and would pollute the results.
-  Tool.appendArgumentsAdjuster(
-      [](const ct::CommandLineArguments &Args, StringRef) {
-        ct::CommandLineArguments filtered;
-        for (size_t i = 0; i < Args.size(); ++i) {
-          if (Args[i] == "-include" && i + 1 < Args.size() &&
-              Args[i + 1] == "cuda_runtime.h") {
-            ++i;
-            continue;
-          }
-          filtered.push_back(Args[i]);
-        }
-        return filtered;
-      });
 
   IncludeCollectorActionFactory factory(outEntries);
   Tool.run(&factory);

--- a/src/LocalHeader.h
+++ b/src/LocalHeader.h
@@ -1,3 +1,25 @@
+/*
+Copyright (c) 2026 - present Advanced Micro Devices, Inc. All rights reserved.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+*/
+
 #pragma once
 
 #include <string>
@@ -12,7 +34,8 @@ extern bool hipifySingleSource(const std::string &srcPath,
                                ct::CommonOptionsParser *OptionsParserPtr,
                                const char *hipify_exe_path,
                                const std::string &mainContextPath,
-                               bool preserveTemp);
+                               bool preserveTemp,
+                               const std::vector<std::string> &additionalIncludes = {});
 
 bool hipifyLocalHeaders(const std::string &srcPath,
                         const ct::CompilationDatabase *compDB,

--- a/src/LocalHeader.h
+++ b/src/LocalHeader.h
@@ -31,10 +31,6 @@ THE SOFTWARE.
 
 namespace ct = clang::tooling;
 
-extern bool appendArgumentsAdjusters(ct::RefactoringTool &Tool,
-                                     const std::string &sSourceAbsPath,
-                                     const char *hipify_exe);
-
 struct IncludeEntry {
   std::string fileName;
   std::string resolvedPath;

--- a/src/LocalHeader.h
+++ b/src/LocalHeader.h
@@ -22,8 +22,6 @@ THE SOFTWARE.
 
 #pragma once
 
-#include "clang/Frontend/FrontendActions.h"
-#include "clang/Lex/PPCallbacks.h"
 #include "clang/Tooling/CommonOptionsParser.h"
 #include "clang/Tooling/Refactoring.h"
 #include <string>
@@ -31,10 +29,14 @@ THE SOFTWARE.
 
 namespace ct = clang::tooling;
 
+// A single `#include` directive, recorded in preprocessing order.
 struct IncludeEntry {
   std::string fileName;
   std::string resolvedPath;
-  bool isAngled;
+  std::string includerPath;
+  bool isAngled = false;
+  bool isSystem = false;
+  bool isFromMainFile = false;
 };
 
 extern bool hipifySingleSource(const std::string &srcPath,
@@ -52,15 +54,9 @@ bool hipifyLocalHeaders(const std::string &srcPath,
                         const char *hipify_exe,
                         bool recursive = false);
 
+// Preprocesses srcPath and records its whole include tree in outEntries.
 bool collectIncludeTree(const std::string &srcPath,
                         const ct::CompilationDatabase *compDB,
                         ct::CommonOptionsParser *OptionsParserPtr,
                         const char *hipify_exe,
-                        const std::string &mainContextPath,
                         std::vector<IncludeEntry> &outEntries);
-
-bool collectLocalQuotedIncludes(const std::string &mainSourceAbsPath,
-                                const ct::CompilationDatabase *compDB,
-                                ct::CommonOptionsParser *OptionsParserPtr,
-                                const char *hipify_exe,
-                                std::vector<std::string> &outHeaders);

--- a/src/LocalHeader.h
+++ b/src/LocalHeader.h
@@ -22,11 +22,24 @@ THE SOFTWARE.
 
 #pragma once
 
+#include "clang/Frontend/FrontendActions.h"
+#include "clang/Lex/PPCallbacks.h"
+#include "clang/Tooling/CommonOptionsParser.h"
+#include "clang/Tooling/Refactoring.h"
 #include <string>
 #include <vector>
-#include "clang/Tooling/CommonOptionsParser.h"
 
 namespace ct = clang::tooling;
+
+extern bool appendArgumentsAdjusters(ct::RefactoringTool &Tool,
+                                     const std::string &sSourceAbsPath,
+                                     const char *hipify_exe);
+
+struct IncludeEntry {
+  std::string fileName;
+  std::string resolvedPath;
+  bool isAngled;
+};
 
 extern bool hipifySingleSource(const std::string &srcPath,
                                const std::string &dstPath,
@@ -43,9 +56,15 @@ bool hipifyLocalHeaders(const std::string &srcPath,
                         const char *hipify_exe,
                         bool recursive = false);
 
-bool resolveLocalInclude(const std::string &mainSourceAbsPath,
-                         const std::string &includeToken,
-                         std::string &outAbsPath);
+bool collectIncludeTree(const std::string &srcPath,
+                        const ct::CompilationDatabase *compDB,
+                        ct::CommonOptionsParser *OptionsParserPtr,
+                        const char *hipify_exe,
+                        const std::string &mainContextPath,
+                        std::vector<IncludeEntry> &outEntries);
 
 bool collectLocalQuotedIncludes(const std::string &mainSourceAbsPath,
+                                const ct::CompilationDatabase *compDB,
+                                ct::CommonOptionsParser *OptionsParserPtr,
+                                const char *hipify_exe,
                                 std::vector<std::string> &outHeaders);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -21,6 +21,7 @@ THE SOFTWARE.
 */
 
 #include <fstream>
+#include <vector>
 #include "CUDA2HIP.h"
 #include "CUDA2HIP_Scripting.h"
 #include "LLVMCompat.h"
@@ -241,7 +242,8 @@ bool hipifySingleSource(const std::string &srcPath,
                                ct::CommonOptionsParser *OptionsParserPtr,
                                const char *hipify_exe_path,
                                const std::string &mainContextPath,
-                               bool preserveTemp) {
+                               bool preserveTemp,
+                               const std::vector<std::string> &additionalIncludes) {
   std::error_code EC;
   SmallString<128> tmpFile;
   StringRef srcFileName = sys::path::filename(srcPath);
@@ -274,6 +276,15 @@ bool hipifySingleSource(const std::string &srcPath,
                  << "LLVM/resource config failed for: " << srcPath << "\n";
     if (!SaveTemps && !preserveTemp) sys::fs::remove(tmpFile);
     return false;
+  }
+
+  for (auto it = additionalIncludes.rbegin(); it != additionalIncludes.rend(); ++it) {
+    Tool.appendArgumentsAdjuster(
+        ct::getInsertArgumentAdjuster(it->c_str(),
+                                       ct::ArgumentInsertPosition::BEGIN));
+    Tool.appendArgumentsAdjuster(
+        ct::getInsertArgumentAdjuster("-include",
+                                       ct::ArgumentInsertPosition::BEGIN));
   }
 
   // Hipify _all_ the things!
@@ -516,15 +527,20 @@ int main(int argc, const char **argv) {
     }
     // Initialise the statistics counters for this file.
     Statistics::setActive(src);
-    // Checks the local headers if --local-headers/--local-header-recursive specified.
     if (OptLocalHeaders || OptLocalHeadersRecursive) {
+      llvm::outs() << "\n" << sHipify
+                   << "Local header hipification enabled ("
+                   << (OptLocalHeadersRecursive ? "recursive" : "non-recursive")
+                   << ") for: " << sys::path::filename(sSourceAbsPath) << "\n";
       if (!hipifyLocalHeaders(sSourceAbsPath,
                               compilationDatabase.get(),
                               &OptionsParser,
                               argv[0],
                               OptLocalHeadersRecursive)) {
+        llvm::errs() << "\n" << sHipify << sError
+                     << "Local header hipification failed for: "
+                     << sys::path::filename(sSourceAbsPath) << "\n";
         Statistics::current().hasErrors = true;
-        LLVM_DEBUG(llvm::dbgs() << "Local header hipification failed for: " << sSourceAbsPath << "\n");
         Result = 1;
       }
     }
@@ -535,7 +551,7 @@ int main(int argc, const char **argv) {
                             &OptionsParser,
                             argv[0],
                             sSourceAbsPath,
-                            false)) {
+                            false, {})) {
       Statistics::current().hasErrors = true;
       Result = 1;
       LLVM_DEBUG(llvm::dbgs() << "Hipification failed for: " << src << "\n");

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -527,16 +527,12 @@ int main(int argc, const char **argv) {
     }
     // Initialise the statistics counters for this file.
     Statistics::setActive(src);
-    if (OptLocalHeaders || OptLocalHeadersRecursive) {
-      llvm::outs() << "\n" << sHipify
-                   << "Local header hipification enabled ("
-                   << (OptLocalHeadersRecursive ? "recursive" : "non-recursive")
-                   << ") for: " << sys::path::filename(sSourceAbsPath) << "\n";
+    if (!SkipLocalHeaders) {
       if (!hipifyLocalHeaders(sSourceAbsPath,
                               compilationDatabase.get(),
                               &OptionsParser,
                               argv[0],
-                              OptLocalHeadersRecursive)) {
+                              true)) {
         llvm::errs() << "\n" << sHipify << sError
                      << "Local header hipification failed for: "
                      << sys::path::filename(sSourceAbsPath) << "\n";

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -278,13 +278,25 @@ bool hipifySingleSource(const std::string &srcPath,
     return false;
   }
 
-  for (auto it = additionalIncludes.rbegin(); it != additionalIncludes.rend(); ++it) {
-    Tool.appendArgumentsAdjuster(
-        ct::getInsertArgumentAdjuster(it->c_str(),
-                                       ct::ArgumentInsertPosition::BEGIN));
-    Tool.appendArgumentsAdjuster(
-        ct::getInsertArgumentAdjuster("-include",
-                                       ct::ArgumentInsertPosition::BEGIN));
+  // The copy is preprocessed from a temporary directory, so includes quoted
+  // relative to the original one need an explicit search path.
+  StringRef srcDir = sys::path::parent_path(srcPath);
+  if (!srcDir.empty()) {
+    std::string sSrcDir = "-I" + srcDir.str();
+    Tool.appendArgumentsAdjuster(ct::getInsertArgumentAdjuster(
+        sSrcDir.c_str(), ct::ArgumentInsertPosition::BEGIN));
+  }
+
+  // Appended at the end to follow the implicit CUDA headers, inserted at the
+  // beginning: a header may use CUDA declarations without including any.
+  if (!additionalIncludes.empty()) {
+    ct::CommandLineArguments includeArgs;
+    for (const std::string &include : additionalIncludes) {
+      includeArgs.push_back("-include");
+      includeArgs.push_back(include);
+    }
+    Tool.appendArgumentsAdjuster(ct::getInsertArgumentAdjuster(
+        includeArgs, ct::ArgumentInsertPosition::END));
   }
 
   // Hipify _all_ the things!

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -527,12 +527,10 @@ int main(int argc, const char **argv) {
     }
     // Initialise the statistics counters for this file.
     Statistics::setActive(src);
-    if (!SkipLocalHeaders) {
-      if (!hipifyLocalHeaders(sSourceAbsPath,
-                              compilationDatabase.get(),
-                              &OptionsParser,
-                              argv[0],
-                              true)) {
+    if (OptLocalHeaders || OptLocalHeadersRecursive) {
+      if (!hipifyLocalHeaders(sSourceAbsPath, compilationDatabase.get(),
+                              &OptionsParser, argv[0],
+                              OptLocalHeadersRecursive)) {
         llvm::errs() << "\n" << sHipify << sError
                      << "Local header hipification failed for: "
                      << sys::path::filename(sSourceAbsPath) << "\n";
@@ -540,7 +538,7 @@ int main(int argc, const char **argv) {
         Result = 1;
       }
     }
-   
+
     std::string outputPath = NoOutput ? "" : dst;
     if (!hipifySingleSource(src, outputPath,
                             compilationDatabase.get(),

--- a/tests/lit.cfg
+++ b/tests/lit.cfg
@@ -19,6 +19,8 @@ config.excludes.append('inc.h')
 config.excludes.append('inet.h')
 config.excludes.append('types.h')
 config.excludes.append('socket.h')
+config.excludes.append('transitive_parent.h')
+config.excludes.append('transitive_child.h')
 
 delimiter = "===============================================================";
 print(delimiter)

--- a/tests/lit.cfg
+++ b/tests/lit.cfg
@@ -21,6 +21,9 @@ config.excludes.append('types.h')
 config.excludes.append('socket.h')
 config.excludes.append('transitive_parent.h')
 config.excludes.append('transitive_child.h')
+config.excludes.append('diamond_left.h')
+config.excludes.append('diamond_right.h')
+config.excludes.append('diamond_shared.h')
 
 delimiter = "===============================================================";
 print(delimiter)

--- a/tests/lit.cfg
+++ b/tests/lit.cfg
@@ -24,6 +24,8 @@ config.excludes.append('transitive_child.h')
 config.excludes.append('diamond_left.h')
 config.excludes.append('diamond_right.h')
 config.excludes.append('diamond_shared.h')
+# Not self-contained by design; only hipifiable through non_self_contained.cu.
+config.excludes.append('nsc_dependent.h')
 
 delimiter = "===============================================================";
 print(delimiter)

--- a/tests/unit_tests/headers/local_headers/angle_bracket.cu
+++ b/tests/unit_tests/headers/local_headers/angle_bracket.cu
@@ -1,4 +1,4 @@
-// RUN: %run_test hipify "%s" "%t" %hipify_args --local-headers %clang_args
+// RUN: %run_test hipify "%s" "%t" %hipify_args %clang_args
 
 // CHECK: #include <hip/hip_runtime.h>
 // CHECK-NOT: #include <cuda_runtime.h>

--- a/tests/unit_tests/headers/local_headers/angle_bracket.cu
+++ b/tests/unit_tests/headers/local_headers/angle_bracket.cu
@@ -1,4 +1,4 @@
-// RUN: %run_test hipify "%s" "%t" %hipify_args --local-headers %clang_args
+// RUN: %run_test hipify "%s" "%t" %hipify_args 1 --local-headers %clang_args
 
 // CHECK: #include <hip/hip_runtime.h>
 // CHECK-NOT: #include <cuda_runtime.h>

--- a/tests/unit_tests/headers/local_headers/angle_bracket.cu
+++ b/tests/unit_tests/headers/local_headers/angle_bracket.cu
@@ -1,4 +1,4 @@
-// RUN: %run_test hipify "%s" "%t" %hipify_args %clang_args
+// RUN: %run_test hipify "%s" "%t" %hipify_args --local-headers %clang_args
 
 // CHECK: #include <hip/hip_runtime.h>
 // CHECK-NOT: #include <cuda_runtime.h>

--- a/tests/unit_tests/headers/local_headers/block_comment_include.h
+++ b/tests/unit_tests/headers/local_headers/block_comment_include.h
@@ -1,0 +1,15 @@
+// RUN: %run_test hipify "%s" "%t" %hipify_args %clang_args
+
+#ifndef BLOCK_COMMENT_INCLUDE_H
+#define BLOCK_COMMENT_INCLUDE_H
+
+// CHECK: #include <hip/hip_runtime.h>
+// CHECK-NOT: #include <cuda_runtime.h>
+#include <cuda_runtime.h>
+
+inline void block_comment_sync() {
+    // CHECK: hipDeviceSynchronize();
+    cudaDeviceSynchronize();
+}
+
+#endif

--- a/tests/unit_tests/headers/local_headers/common.h
+++ b/tests/unit_tests/headers/local_headers/common.h
@@ -1,4 +1,4 @@
-// RUN: %run_test hipify "%s" "%t" %hipify_args --local-headers %clang_args
+// RUN: %run_test hipify "%s" "%t" %hipify_args %clang_args
 
 #ifndef COMMON_H
 #define COMMON_H

--- a/tests/unit_tests/headers/local_headers/common.h
+++ b/tests/unit_tests/headers/local_headers/common.h
@@ -1,4 +1,4 @@
-// RUN: %run_test hipify "%s" "%t" %hipify_args --local-headers %clang_args
+// RUN: %run_test hipify "%s" "%t" %hipify_args 1 --local-headers %clang_args
 
 #ifndef COMMON_H
 #define COMMON_H

--- a/tests/unit_tests/headers/local_headers/common.h
+++ b/tests/unit_tests/headers/local_headers/common.h
@@ -1,4 +1,4 @@
-// RUN: %run_test hipify "%s" "%t" %hipify_args %clang_args
+// RUN: %run_test hipify "%s" "%t" %hipify_args --local-headers %clang_args
 
 #ifndef COMMON_H
 #define COMMON_H

--- a/tests/unit_tests/headers/local_headers/cyclic_header.cu
+++ b/tests/unit_tests/headers/local_headers/cyclic_header.cu
@@ -1,4 +1,4 @@
-// RUN: %run_test hipify "%s" "%t" %hipify_args --local-headers-recursive %clang_args
+// RUN: %run_test hipify "%s" "%t" %hipify_args %clang_args
 
 // CHECK: #include <hip/hip_runtime.h>
 // CHECK-NOT: #include <cuda_runtime.h>

--- a/tests/unit_tests/headers/local_headers/cyclic_header.cu
+++ b/tests/unit_tests/headers/local_headers/cyclic_header.cu
@@ -1,4 +1,5 @@
-// RUN: %run_test hipify "%s" "%t" %hipify_args %clang_args
+// RUN: %run_test hipify "%s" "%t" %hipify_args --local-headers-recursive
+// %clang_args
 
 // CHECK: #include <hip/hip_runtime.h>
 // CHECK-NOT: #include <cuda_runtime.h>

--- a/tests/unit_tests/headers/local_headers/diamond_dep.cu
+++ b/tests/unit_tests/headers/local_headers/diamond_dep.cu
@@ -2,7 +2,12 @@
 
 // CHECK: #include <hip/hip_runtime.h>
 // CHECK-NOT: #include <cuda_runtime.h>
-// CHECK: #include "common.h"
+// CHECK: #include "diamond_left.h"
+// CHECK: #include "diamond_right.h"
 #include <cuda_runtime.h>
-#include "common.h"
-int main(){}
+#include "diamond_left.h"
+#include "diamond_right.h"
+
+int main() {
+    return 0;
+}

--- a/tests/unit_tests/headers/local_headers/diamond_left.h
+++ b/tests/unit_tests/headers/local_headers/diamond_left.h
@@ -1,0 +1,11 @@
+#ifndef DIAMOND_LEFT_H
+#define DIAMOND_LEFT_H
+
+#include "diamond_shared.h"
+
+inline void left_sync() {
+    // CHECK: hipDeviceSynchronize();
+    cudaDeviceSynchronize();
+}
+
+#endif

--- a/tests/unit_tests/headers/local_headers/diamond_right.h
+++ b/tests/unit_tests/headers/local_headers/diamond_right.h
@@ -1,0 +1,11 @@
+#ifndef DIAMOND_RIGHT_H
+#define DIAMOND_RIGHT_H
+
+#include "diamond_shared.h"
+
+inline void right_free(void *p) {
+    // CHECK: hipFree(p);
+    cudaFree(p);
+}
+
+#endif

--- a/tests/unit_tests/headers/local_headers/diamond_shared.h
+++ b/tests/unit_tests/headers/local_headers/diamond_shared.h
@@ -1,0 +1,9 @@
+#ifndef DIAMOND_SHARED_H
+#define DIAMOND_SHARED_H
+
+inline void shared_alloc(void **p, size_t size) {
+    // CHECK: hipMalloc(p, size);
+    cudaMalloc(p, size);
+}
+
+#endif

--- a/tests/unit_tests/headers/local_headers/duplicate.h
+++ b/tests/unit_tests/headers/local_headers/duplicate.h
@@ -1,4 +1,4 @@
-// RUN: %run_test hipify "%s" "%t" %hipify_args --local-headers %clang_args
+// RUN: %run_test hipify "%s" "%t" %hipify_args %clang_args
 
 #ifndef DUP_H
 #define DUP_H

--- a/tests/unit_tests/headers/local_headers/duplicate_header.cu
+++ b/tests/unit_tests/headers/local_headers/duplicate_header.cu
@@ -1,4 +1,4 @@
-// RUN: %run_test hipify "%s" "%t" %hipify_args --local-headers %clang_args
+// RUN: %run_test hipify "%s" "%t" %hipify_args %clang_args
 
 // CHECK: #include <hip/hip_runtime.h>
 // CHECK: #include "duplicate.h"

--- a/tests/unit_tests/headers/local_headers/duplicate_header.cu
+++ b/tests/unit_tests/headers/local_headers/duplicate_header.cu
@@ -1,4 +1,4 @@
-// RUN: %run_test hipify "%s" "%t" %hipify_args --local-headers %clang_args
+// RUN: %run_test hipify "%s" "%t" %hipify_args 1 --local-headers %clang_args
 
 // CHECK: #include <hip/hip_runtime.h>
 // CHECK: #include "duplicate.h"

--- a/tests/unit_tests/headers/local_headers/duplicate_header.cu
+++ b/tests/unit_tests/headers/local_headers/duplicate_header.cu
@@ -1,4 +1,4 @@
-// RUN: %run_test hipify "%s" "%t" %hipify_args %clang_args
+// RUN: %run_test hipify "%s" "%t" %hipify_args --local-headers %clang_args
 
 // CHECK: #include <hip/hip_runtime.h>
 // CHECK: #include "duplicate.h"

--- a/tests/unit_tests/headers/local_headers/injection_has_cmath.h
+++ b/tests/unit_tests/headers/local_headers/injection_has_cmath.h
@@ -1,0 +1,16 @@
+// RUN: %run_test hipify "%s" "%t" %hipify_args --local-headers %clang_args
+
+#ifndef INJECTION_HAS_CMATH_H
+#define INJECTION_HAS_CMATH_H
+
+// CHECK: #include <hip/hip_runtime.h>
+// CHECK-NOT: #include <cuda_runtime.h>
+// CHECK: #include <cmath>
+#include <cuda_runtime.h>
+#include <cmath>
+
+inline float compute_value(float x) {
+    return sqrtf(x) + 1.0f;
+}
+
+#endif

--- a/tests/unit_tests/headers/local_headers/injection_has_cmath.h
+++ b/tests/unit_tests/headers/local_headers/injection_has_cmath.h
@@ -1,4 +1,4 @@
-// RUN: %run_test hipify "%s" "%t" %hipify_args --local-headers %clang_args
+// RUN: %run_test hipify "%s" "%t" %hipify_args %clang_args
 
 #ifndef INJECTION_HAS_CMATH_H
 #define INJECTION_HAS_CMATH_H

--- a/tests/unit_tests/headers/local_headers/injection_helper.h
+++ b/tests/unit_tests/headers/local_headers/injection_helper.h
@@ -1,0 +1,22 @@
+// RUN: %run_test hipify "%s" "%t" %hipify_args --local-headers %clang_args
+
+#ifndef INJECTION_HELPER_H
+#define INJECTION_HELPER_H
+
+// CHECK: #include <hip/hip_runtime.h>
+// CHECK-NOT: #include <cuda_runtime.h>
+#include <cuda_runtime.h>
+
+inline __device__ float3 add_vectors(float3 a, float3 b) {
+    return make_float3(0.0f, 0.0f, 0.0f);
+}
+
+inline __device__ void accumulate(float3* sum, float3 val) {
+    return;
+}
+
+inline __device__ float3 scale_and_diff(float3 a, float3 b, float s) {
+    return make_float3(0.0f, 0.0f, 0.0f);
+}
+
+#endif

--- a/tests/unit_tests/headers/local_headers/injection_helper.h
+++ b/tests/unit_tests/headers/local_headers/injection_helper.h
@@ -1,4 +1,4 @@
-// RUN: %run_test hipify "%s" "%t" %hipify_args --local-headers %clang_args
+// RUN: %run_test hipify "%s" "%t" %hipify_args %clang_args
 
 #ifndef INJECTION_HELPER_H
 #define INJECTION_HELPER_H

--- a/tests/unit_tests/headers/local_headers/injection_inner.h
+++ b/tests/unit_tests/headers/local_headers/injection_inner.h
@@ -1,4 +1,4 @@
-// RUN: %run_test hipify "%s" "%t" %hipify_args --local-headers-recursive %clang_args
+// RUN: %run_test hipify "%s" "%t" %hipify_args %clang_args
 
 #ifndef INJECTION_INNER_H
 #define INJECTION_INNER_H

--- a/tests/unit_tests/headers/local_headers/injection_inner.h
+++ b/tests/unit_tests/headers/local_headers/injection_inner.h
@@ -1,0 +1,14 @@
+// RUN: %run_test hipify "%s" "%t" %hipify_args --local-headers-recursive %clang_args
+
+#ifndef INJECTION_INNER_H
+#define INJECTION_INNER_H
+
+// CHECK: #include <hip/hip_runtime.h>
+// CHECK-NOT: #include <cuda_runtime.h>
+#include <cuda_runtime.h>
+
+inline __device__ void inner_add(float3* data, int idx) {
+    return;
+}
+
+#endif

--- a/tests/unit_tests/headers/local_headers/injection_multi.cu
+++ b/tests/unit_tests/headers/local_headers/injection_multi.cu
@@ -1,4 +1,4 @@
-// RUN: %run_test hipify "%s" "%t" %hipify_args --local-headers %clang_args
+// RUN: %run_test hipify "%s" "%t" %hipify_args %clang_args
 
 // CHECK: #include <hip/hip_runtime.h>
 // CHECK-NOT: #include <cuda_runtime.h>

--- a/tests/unit_tests/headers/local_headers/injection_multi.cu
+++ b/tests/unit_tests/headers/local_headers/injection_multi.cu
@@ -1,0 +1,22 @@
+// RUN: %run_test hipify "%s" "%t" %hipify_args --local-headers %clang_args
+
+// CHECK: #include <hip/hip_runtime.h>
+// CHECK-NOT: #include <cuda_runtime.h>
+// CHECK: #include <cmath>
+// CHECK: #include "vector_math.h"
+// CHECK: #include "injection_helper.h"
+// CHECK: #include "injection_uses_cmath.h"
+#include <cuda_runtime.h>
+#include <cmath>
+#include "vector_math.h"
+#include "injection_helper.h"
+#include "injection_uses_cmath.h"
+
+__global__ void multiKernel(float3* data, float* vals) {
+    int idx = threadIdx.x;
+    dummy_vector_op();
+    add_vectors(data[idx], data[idx + 1]);
+    vals[idx] = compute_sqrt(vals[idx]);
+}
+
+int main() { return 0; }

--- a/tests/unit_tests/headers/local_headers/injection_multi.cu
+++ b/tests/unit_tests/headers/local_headers/injection_multi.cu
@@ -1,4 +1,4 @@
-// RUN: %run_test hipify "%s" "%t" %hipify_args --local-headers %clang_args
+// RUN: %run_test hipify "%s" "%t" %hipify_args 1 --local-headers %clang_args
 
 // CHECK: #include <hip/hip_runtime.h>
 // CHECK-NOT: #include <cuda_runtime.h>

--- a/tests/unit_tests/headers/local_headers/injection_multi.cu
+++ b/tests/unit_tests/headers/local_headers/injection_multi.cu
@@ -1,4 +1,4 @@
-// RUN: %run_test hipify "%s" "%t" %hipify_args %clang_args
+// RUN: %run_test hipify "%s" "%t" %hipify_args --local-headers %clang_args
 
 // CHECK: #include <hip/hip_runtime.h>
 // CHECK-NOT: #include <cuda_runtime.h>

--- a/tests/unit_tests/headers/local_headers/injection_no_duplicate.cu
+++ b/tests/unit_tests/headers/local_headers/injection_no_duplicate.cu
@@ -1,4 +1,4 @@
-// RUN: %run_test hipify "%s" "%t" %hipify_args --local-headers %clang_args
+// RUN: %run_test hipify "%s" "%t" %hipify_args %clang_args
 
 // CHECK: #include <hip/hip_runtime.h>
 // CHECK-NOT: #include <cuda_runtime.h>

--- a/tests/unit_tests/headers/local_headers/injection_no_duplicate.cu
+++ b/tests/unit_tests/headers/local_headers/injection_no_duplicate.cu
@@ -1,0 +1,14 @@
+// RUN: %run_test hipify "%s" "%t" %hipify_args --local-headers %clang_args
+
+// CHECK: #include <hip/hip_runtime.h>
+// CHECK-NOT: #include <cuda_runtime.h>
+// CHECK: #include <cmath>
+// CHECK: #include "injection_has_cmath.h"
+#include <cuda_runtime.h>
+#include <cmath>
+#include "injection_has_cmath.h"
+
+int main() {
+    float x = compute_value(4.0f);
+    return (int)x;
+}

--- a/tests/unit_tests/headers/local_headers/injection_no_duplicate.cu
+++ b/tests/unit_tests/headers/local_headers/injection_no_duplicate.cu
@@ -1,4 +1,4 @@
-// RUN: %run_test hipify "%s" "%t" %hipify_args --local-headers %clang_args
+// RUN: %run_test hipify "%s" "%t" %hipify_args 1 --local-headers %clang_args
 
 // CHECK: #include <hip/hip_runtime.h>
 // CHECK-NOT: #include <cuda_runtime.h>

--- a/tests/unit_tests/headers/local_headers/injection_no_duplicate.cu
+++ b/tests/unit_tests/headers/local_headers/injection_no_duplicate.cu
@@ -1,4 +1,4 @@
-// RUN: %run_test hipify "%s" "%t" %hipify_args %clang_args
+// RUN: %run_test hipify "%s" "%t" %hipify_args --local-headers %clang_args
 
 // CHECK: #include <hip/hip_runtime.h>
 // CHECK-NOT: #include <cuda_runtime.h>

--- a/tests/unit_tests/headers/local_headers/injection_outer.h
+++ b/tests/unit_tests/headers/local_headers/injection_outer.h
@@ -1,0 +1,16 @@
+// RUN: %run_test hipify "%s" "%t" %hipify_args --local-headers-recursive %clang_args
+
+#ifndef INJECTION_OUTER_H
+#define INJECTION_OUTER_H
+
+// CHECK: #include <hip/hip_runtime.h>
+// CHECK-NOT: #include <cuda_runtime.h>
+// CHECK: #include "injection_inner.h"
+#include <cuda_runtime.h>
+#include "injection_inner.h"
+
+inline __device__ void outer_process(float3* data, int idx) {
+    inner_add(data, idx);
+}
+
+#endif

--- a/tests/unit_tests/headers/local_headers/injection_outer.h
+++ b/tests/unit_tests/headers/local_headers/injection_outer.h
@@ -1,4 +1,4 @@
-// RUN: %run_test hipify "%s" "%t" %hipify_args --local-headers-recursive %clang_args
+// RUN: %run_test hipify "%s" "%t" %hipify_args %clang_args
 
 #ifndef INJECTION_OUTER_H
 #define INJECTION_OUTER_H

--- a/tests/unit_tests/headers/local_headers/injection_pragma_header.h
+++ b/tests/unit_tests/headers/local_headers/injection_pragma_header.h
@@ -1,0 +1,11 @@
+// RUN: %run_test hipify "%s" "%t" %hipify_args --local-headers %clang_args
+
+#pragma once
+
+// CHECK: #include <hip/hip_runtime.h>
+// CHECK-NOT: #include <cuda_runtime.h>
+#include <cuda_runtime.h>
+
+inline __device__ void pragma_add(float3* data, int idx) {
+    return;
+}

--- a/tests/unit_tests/headers/local_headers/injection_pragma_header.h
+++ b/tests/unit_tests/headers/local_headers/injection_pragma_header.h
@@ -1,4 +1,4 @@
-// RUN: %run_test hipify "%s" "%t" %hipify_args --local-headers %clang_args
+// RUN: %run_test hipify "%s" "%t" %hipify_args %clang_args
 
 #pragma once
 

--- a/tests/unit_tests/headers/local_headers/injection_pragma_once.cu
+++ b/tests/unit_tests/headers/local_headers/injection_pragma_once.cu
@@ -1,4 +1,4 @@
-// RUN: %run_test hipify "%s" "%t" %hipify_args --local-headers %clang_args
+// RUN: %run_test hipify "%s" "%t" %hipify_args %clang_args
 
 // CHECK: #include <hip/hip_runtime.h>
 // CHECK-NOT: #include <cuda_runtime.h>

--- a/tests/unit_tests/headers/local_headers/injection_pragma_once.cu
+++ b/tests/unit_tests/headers/local_headers/injection_pragma_once.cu
@@ -1,0 +1,17 @@
+// RUN: %run_test hipify "%s" "%t" %hipify_args --local-headers %clang_args
+
+// CHECK: #include <hip/hip_runtime.h>
+// CHECK-NOT: #include <cuda_runtime.h>
+// CHECK: #include "vector_math.h"
+// CHECK: #include "injection_pragma_header.h"
+#include <cuda_runtime.h>
+#include "vector_math.h"
+#include "injection_pragma_header.h"
+
+__global__ void pragmaKernel(float3* data) {
+    int idx = threadIdx.x;
+    dummy_vector_op();
+    pragma_add(data, idx);
+}
+
+int main() { return 0; }

--- a/tests/unit_tests/headers/local_headers/injection_pragma_once.cu
+++ b/tests/unit_tests/headers/local_headers/injection_pragma_once.cu
@@ -1,4 +1,4 @@
-// RUN: %run_test hipify "%s" "%t" %hipify_args --local-headers %clang_args
+// RUN: %run_test hipify "%s" "%t" %hipify_args 1 --local-headers %clang_args
 
 // CHECK: #include <hip/hip_runtime.h>
 // CHECK-NOT: #include <cuda_runtime.h>

--- a/tests/unit_tests/headers/local_headers/injection_pragma_once.cu
+++ b/tests/unit_tests/headers/local_headers/injection_pragma_once.cu
@@ -1,4 +1,4 @@
-// RUN: %run_test hipify "%s" "%t" %hipify_args %clang_args
+// RUN: %run_test hipify "%s" "%t" %hipify_args --local-headers %clang_args
 
 // CHECK: #include <hip/hip_runtime.h>
 // CHECK-NOT: #include <cuda_runtime.h>

--- a/tests/unit_tests/headers/local_headers/injection_recursive.cu
+++ b/tests/unit_tests/headers/local_headers/injection_recursive.cu
@@ -1,4 +1,4 @@
-// RUN: %run_test hipify "%s" "%t" %hipify_args --local-headers-recursive %clang_args
+// RUN: %run_test hipify "%s" "%t" %hipify_args %clang_args
 
 // CHECK: #include <hip/hip_runtime.h>
 // CHECK-NOT: #include <cuda_runtime.h>

--- a/tests/unit_tests/headers/local_headers/injection_recursive.cu
+++ b/tests/unit_tests/headers/local_headers/injection_recursive.cu
@@ -1,0 +1,17 @@
+// RUN: %run_test hipify "%s" "%t" %hipify_args --local-headers-recursive %clang_args
+
+// CHECK: #include <hip/hip_runtime.h>
+// CHECK-NOT: #include <cuda_runtime.h>
+// CHECK: #include "vector_math.h"
+// CHECK: #include "injection_outer.h"
+#include <cuda_runtime.h>
+#include "vector_math.h"
+#include "injection_outer.h"
+
+__global__ void recursiveKernel(float3* data) {
+    int idx = threadIdx.x;
+    dummy_vector_op();
+    outer_process(data, idx);
+}
+
+int main() { return 0; }

--- a/tests/unit_tests/headers/local_headers/injection_recursive.cu
+++ b/tests/unit_tests/headers/local_headers/injection_recursive.cu
@@ -1,4 +1,5 @@
-// RUN: %run_test hipify "%s" "%t" %hipify_args %clang_args
+// RUN: %run_test hipify "%s" "%t" %hipify_args --local-headers-recursive
+// %clang_args
 
 // CHECK: #include <hip/hip_runtime.h>
 // CHECK-NOT: #include <cuda_runtime.h>

--- a/tests/unit_tests/headers/local_headers/injection_recursive.cu
+++ b/tests/unit_tests/headers/local_headers/injection_recursive.cu
@@ -1,5 +1,4 @@
-// RUN: %run_test hipify "%s" "%t" %hipify_args --local-headers-recursive
-// %clang_args
+// RUN: %run_test hipify "%s" "%t" %hipify_args 1 --local-headers-recursive %clang_args
 
 // CHECK: #include <hip/hip_runtime.h>
 // CHECK-NOT: #include <cuda_runtime.h>

--- a/tests/unit_tests/headers/local_headers/injection_test.cu
+++ b/tests/unit_tests/headers/local_headers/injection_test.cu
@@ -1,4 +1,4 @@
-// RUN: %run_test hipify "%s" "%t" %hipify_args --local-headers %clang_args
+// RUN: %run_test hipify "%s" "%t" %hipify_args %clang_args
 
 // CHECK: #include <hip/hip_runtime.h>
 // CHECK-NOT: #include <cuda_runtime.h>

--- a/tests/unit_tests/headers/local_headers/injection_test.cu
+++ b/tests/unit_tests/headers/local_headers/injection_test.cu
@@ -1,0 +1,17 @@
+// RUN: %run_test hipify "%s" "%t" %hipify_args --local-headers %clang_args
+
+// CHECK: #include <hip/hip_runtime.h>
+// CHECK-NOT: #include <cuda_runtime.h>
+// CHECK: #include "vector_math.h"
+// CHECK: #include "injection_helper.h"
+#include <cuda_runtime.h>
+#include "vector_math.h"
+#include "injection_helper.h"
+
+__global__ void testKernel(float3* data) {
+    int idx = threadIdx.x;
+    dummy_vector_op();
+    add_vectors(data[idx], data[idx + 1]);
+}
+
+int main() { return 0; }

--- a/tests/unit_tests/headers/local_headers/injection_test.cu
+++ b/tests/unit_tests/headers/local_headers/injection_test.cu
@@ -1,4 +1,4 @@
-// RUN: %run_test hipify "%s" "%t" %hipify_args --local-headers %clang_args
+// RUN: %run_test hipify "%s" "%t" %hipify_args 1 --local-headers %clang_args
 
 // CHECK: #include <hip/hip_runtime.h>
 // CHECK-NOT: #include <cuda_runtime.h>

--- a/tests/unit_tests/headers/local_headers/injection_test.cu
+++ b/tests/unit_tests/headers/local_headers/injection_test.cu
@@ -1,4 +1,4 @@
-// RUN: %run_test hipify "%s" "%t" %hipify_args %clang_args
+// RUN: %run_test hipify "%s" "%t" %hipify_args --local-headers %clang_args
 
 // CHECK: #include <hip/hip_runtime.h>
 // CHECK-NOT: #include <cuda_runtime.h>

--- a/tests/unit_tests/headers/local_headers/injection_uses_cmath.h
+++ b/tests/unit_tests/headers/local_headers/injection_uses_cmath.h
@@ -1,4 +1,4 @@
-// RUN: %run_test hipify "%s" "%t" %hipify_args --local-headers %clang_args
+// RUN: %run_test hipify "%s" "%t" %hipify_args %clang_args
 
 #ifndef INJECTION_USES_CMATH_H
 #define INJECTION_USES_CMATH_H

--- a/tests/unit_tests/headers/local_headers/injection_uses_cmath.h
+++ b/tests/unit_tests/headers/local_headers/injection_uses_cmath.h
@@ -1,0 +1,18 @@
+// RUN: %run_test hipify "%s" "%t" %hipify_args --local-headers %clang_args
+
+#ifndef INJECTION_USES_CMATH_H
+#define INJECTION_USES_CMATH_H
+
+// CHECK: #include <hip/hip_runtime.h>
+// CHECK-NOT: #include <cuda_runtime.h>
+#include <cuda_runtime.h>
+
+inline __device__ float compute_sqrt(float x) {
+    return sqrtf(x);
+}
+
+inline __device__ float compute_magnitude(float x, float y) {
+    return sqrtf(x * x + y * y);
+}
+
+#endif

--- a/tests/unit_tests/headers/local_headers/local_angle.h
+++ b/tests/unit_tests/headers/local_headers/local_angle.h
@@ -1,4 +1,4 @@
-// RUN: %run_test hipify "%s" "%t" %hipify_args --local-headers %clang_args
+// RUN: %run_test hipify "%s" "%t" %hipify_args %clang_args
 #ifndef LOCAL_ANGLE_H
 #define LOCAL_ANGLE_H
 // CHECK: #include <hip/hip_runtime.h>

--- a/tests/unit_tests/headers/local_headers/main.cu
+++ b/tests/unit_tests/headers/local_headers/main.cu
@@ -1,4 +1,4 @@
-// RUN: %run_test hipify "%s" "%t" %hipify_args --local-headers %clang_args
+// RUN: %run_test hipify "%s" "%t" %hipify_args %clang_args
 
 // CHECK: #include <hip/hip_runtime.h>
 // CHECK-NOT: #include <cuda_runtime.h>

--- a/tests/unit_tests/headers/local_headers/main.cu
+++ b/tests/unit_tests/headers/local_headers/main.cu
@@ -5,8 +5,21 @@
 // CHECK: #include "common.h"
 // CHECK: #include "single_header.h"
 // CHECK: #include "shared.h"
+// CHECK: #include "block_comment_include.h"
+// CHECK: #include "parent_a.h"
+// CHECK: #include "parent_b.h"
+// CHECK: #include "subdir_a/dup_name.h"
+// CHECK: #include "subdir_b/dup_name.h"
 #include <cuda_runtime.h>
 
 #include "common.h"
 #include "single_header.h"
 #include "shared.h"
+
+#include "block_comment_include.h" /* block comment after include */
+
+#include "parent_a.h"
+#include "parent_b.h"
+
+#include "subdir_a/dup_name.h"
+#include "subdir_b/dup_name.h"

--- a/tests/unit_tests/headers/local_headers/main.cu
+++ b/tests/unit_tests/headers/local_headers/main.cu
@@ -1,4 +1,4 @@
-// RUN: %run_test hipify "%s" "%t" %hipify_args --local-headers %clang_args
+// RUN: %run_test hipify "%s" "%t" %hipify_args 1 --local-headers %clang_args
 
 // CHECK: #include <hip/hip_runtime.h>
 // CHECK-NOT: #include <cuda_runtime.h>

--- a/tests/unit_tests/headers/local_headers/main.cu
+++ b/tests/unit_tests/headers/local_headers/main.cu
@@ -1,4 +1,4 @@
-// RUN: %run_test hipify "%s" "%t" %hipify_args %clang_args
+// RUN: %run_test hipify "%s" "%t" %hipify_args --local-headers %clang_args
 
 // CHECK: #include <hip/hip_runtime.h>
 // CHECK-NOT: #include <cuda_runtime.h>

--- a/tests/unit_tests/headers/local_headers/mixed.h
+++ b/tests/unit_tests/headers/local_headers/mixed.h
@@ -1,4 +1,4 @@
-// RUN: %run_test hipify "%s" "%t" %hipify_args --local-headers %clang_args
+// RUN: %run_test hipify "%s" "%t" %hipify_args %clang_args
 #ifndef MIXED_H
 #define MIXED_H
 // CHECK: #include <hip/hip_runtime.h>

--- a/tests/unit_tests/headers/local_headers/mixed.h
+++ b/tests/unit_tests/headers/local_headers/mixed.h
@@ -1,4 +1,4 @@
-// RUN: %run_test hipify "%s" "%t" %hipify_args %clang_args
+// RUN: %run_test hipify "%s" "%t" %hipify_args --local-headers %clang_args
 #ifndef MIXED_H
 #define MIXED_H
 // CHECK: #include <hip/hip_runtime.h>

--- a/tests/unit_tests/headers/local_headers/mixed.h
+++ b/tests/unit_tests/headers/local_headers/mixed.h
@@ -1,4 +1,4 @@
-// RUN: %run_test hipify "%s" "%t" %hipify_args --local-headers %clang_args
+// RUN: %run_test hipify "%s" "%t" %hipify_args 1 --local-headers %clang_args
 #ifndef MIXED_H
 #define MIXED_H
 // CHECK: #include <hip/hip_runtime.h>

--- a/tests/unit_tests/headers/local_headers/no_local_headers.cu
+++ b/tests/unit_tests/headers/local_headers/no_local_headers.cu
@@ -1,4 +1,4 @@
-// RUN: %run_test hipify "%s" "%t" %hipify_args --local-headers %clang_args
+// RUN: %run_test hipify "%s" "%t" %hipify_args %clang_args
 
 // CHECK: #include <hip/hip_runtime.h>
 // CHECK-NOT: #include <cuda_runtime.h>

--- a/tests/unit_tests/headers/local_headers/no_local_headers.cu
+++ b/tests/unit_tests/headers/local_headers/no_local_headers.cu
@@ -1,4 +1,4 @@
-// RUN: %run_test hipify "%s" "%t" %hipify_args --local-headers %clang_args
+// RUN: %run_test hipify "%s" "%t" %hipify_args 1 --local-headers %clang_args
 
 // CHECK: #include <hip/hip_runtime.h>
 // CHECK-NOT: #include <cuda_runtime.h>

--- a/tests/unit_tests/headers/local_headers/no_local_headers.cu
+++ b/tests/unit_tests/headers/local_headers/no_local_headers.cu
@@ -1,4 +1,4 @@
-// RUN: %run_test hipify "%s" "%t" %hipify_args %clang_args
+// RUN: %run_test hipify "%s" "%t" %hipify_args --local-headers %clang_args
 
 // CHECK: #include <hip/hip_runtime.h>
 // CHECK-NOT: #include <cuda_runtime.h>

--- a/tests/unit_tests/headers/local_headers/non_cuda.h
+++ b/tests/unit_tests/headers/local_headers/non_cuda.h
@@ -1,4 +1,4 @@
-// RUN: %run_test hipify "%s" "%t" %hipify_args --local-headers %clang_args
+// RUN: %run_test hipify "%s" "%t" %hipify_args %clang_args
 
 #ifndef NON_CUDA_H
 #define NON_CUDA_H

--- a/tests/unit_tests/headers/local_headers/non_cuda_header.cu
+++ b/tests/unit_tests/headers/local_headers/non_cuda_header.cu
@@ -1,4 +1,4 @@
-// RUN: %run_test hipify "%s" "%t" %hipify_args --local-headers %clang_args
+// RUN: %run_test hipify "%s" "%t" %hipify_args %clang_args
 
 // CHECK: #include <hip/hip_runtime.h>
 // CHECK: #include "non_cuda.h"

--- a/tests/unit_tests/headers/local_headers/non_cuda_header.cu
+++ b/tests/unit_tests/headers/local_headers/non_cuda_header.cu
@@ -1,4 +1,4 @@
-// RUN: %run_test hipify "%s" "%t" %hipify_args %clang_args
+// RUN: %run_test hipify "%s" "%t" %hipify_args --local-headers %clang_args
 
 // CHECK: #include <hip/hip_runtime.h>
 // CHECK: #include "non_cuda.h"

--- a/tests/unit_tests/headers/local_headers/non_cuda_header.cu
+++ b/tests/unit_tests/headers/local_headers/non_cuda_header.cu
@@ -1,4 +1,4 @@
-// RUN: %run_test hipify "%s" "%t" %hipify_args --local-headers %clang_args
+// RUN: %run_test hipify "%s" "%t" %hipify_args 1 --local-headers %clang_args
 
 // CHECK: #include <hip/hip_runtime.h>
 // CHECK: #include "non_cuda.h"

--- a/tests/unit_tests/headers/local_headers/non_self_contained.cu
+++ b/tests/unit_tests/headers/local_headers/non_self_contained.cu
@@ -1,0 +1,23 @@
+// RUN: %run_test hipify "%s" "%t" %hipify_args 1 --local-headers %clang_args
+
+// nsc_dependent.h uses a type from nsc_context.h without including it, so it
+// hipifies only if the includes preceding it here are replayed in front of it.
+
+// CHECK: #include <hip/hip_runtime.h>
+// CHECK-NOT: #include <cuda_runtime.h>
+// CHECK: #include "nsc_context.h"
+// CHECK: #include "nsc_dependent.h"
+#include <cuda_runtime.h>
+#include "nsc_context.h"
+#include "nsc_dependent.h"
+
+__global__ void nscKernel(NscVec* vectors) {
+    int idx = threadIdx.x;
+    vectors[idx].data = make_float3(0.0f, 0.0f, 0.0f);
+}
+
+int main() {
+    NscVec vec;
+    nsc_fill(&vec, 1);
+    return 0;
+}

--- a/tests/unit_tests/headers/local_headers/nsc_context.h
+++ b/tests/unit_tests/headers/local_headers/nsc_context.h
@@ -1,0 +1,15 @@
+// RUN: %run_test hipify "%s" "%t" %hipify_args %clang_args
+
+#ifndef NSC_CONTEXT_H
+#define NSC_CONTEXT_H
+
+// CHECK: #include <hip/hip_runtime.h>
+// CHECK-NOT: #include <cuda_runtime.h>
+#include <cuda_runtime.h>
+
+struct NscVec {
+    float3 data;
+    cudaError_t status;
+};
+
+#endif

--- a/tests/unit_tests/headers/local_headers/nsc_dependent.h
+++ b/tests/unit_tests/headers/local_headers/nsc_dependent.h
@@ -1,0 +1,12 @@
+#ifndef NSC_DEPENDENT_H
+#define NSC_DEPENDENT_H
+
+// Deliberately not self-contained: NscVec comes from the includer. Driven by
+// non_self_contained.cu, and excluded from standalone testing in tests/lit.cfg.
+
+inline cudaError_t nsc_fill(NscVec *v, int count) {
+    v->status = cudaMemset(&v->data, 0, count * sizeof(float3));
+    return v->status;
+}
+
+#endif

--- a/tests/unit_tests/headers/local_headers/parent_a.h
+++ b/tests/unit_tests/headers/local_headers/parent_a.h
@@ -1,0 +1,17 @@
+// RUN: %run_test hipify "%s" "%t" %hipify_args %clang_args
+
+#ifndef PARENT_A_H
+#define PARENT_A_H
+
+// CHECK: #include <hip/hip_runtime.h>
+// CHECK-NOT: #include <cuda_runtime.h>
+// CHECK: #include "shared_dep.h"
+#include <cuda_runtime.h>
+#include "shared_dep.h"
+
+inline void parent_a_malloc(void **p) {
+    // CHECK: hipMalloc(p, 32);
+    cudaMalloc(p, 32);
+}
+
+#endif

--- a/tests/unit_tests/headers/local_headers/parent_b.h
+++ b/tests/unit_tests/headers/local_headers/parent_b.h
@@ -1,0 +1,17 @@
+// RUN: %run_test hipify "%s" "%t" %hipify_args %clang_args
+
+#ifndef PARENT_B_H
+#define PARENT_B_H
+
+// CHECK: #include <hip/hip_runtime.h>
+// CHECK-NOT: #include <cuda_runtime.h>
+// CHECK: #include "shared_dep.h"
+#include <cuda_runtime.h>
+#include "shared_dep.h"
+
+inline void parent_b_free(void *p) {
+    // CHECK: hipFree(p);
+    cudaFree(p);
+}
+
+#endif

--- a/tests/unit_tests/headers/local_headers/rec_1.h
+++ b/tests/unit_tests/headers/local_headers/rec_1.h
@@ -1,4 +1,4 @@
-// RUN: %run_test hipify "%s" "%t" %hipify_args --local-headers-recursive %clang_args
+// RUN: %run_test hipify "%s" "%t" %hipify_args %clang_args
 
 #ifndef REC_H
 #define REC_H

--- a/tests/unit_tests/headers/local_headers/recursive-header.cu
+++ b/tests/unit_tests/headers/local_headers/recursive-header.cu
@@ -1,4 +1,4 @@
-// RUN: %run_test hipify "%s" "%t" %hipify_args --local-headers-recursive %clang_args
+// RUN: %run_test hipify "%s" "%t" %hipify_args %clang_args
 
 // CHECK: #include <hip/hip_runtime.h>
 // CHECK-NOT: #include <cuda_runtime.h>

--- a/tests/unit_tests/headers/local_headers/recursive-header.cu
+++ b/tests/unit_tests/headers/local_headers/recursive-header.cu
@@ -1,4 +1,5 @@
-// RUN: %run_test hipify "%s" "%t" %hipify_args %clang_args
+// RUN: %run_test hipify "%s" "%t" %hipify_args --local-headers-recursive
+// %clang_args
 
 // CHECK: #include <hip/hip_runtime.h>
 // CHECK-NOT: #include <cuda_runtime.h>

--- a/tests/unit_tests/headers/local_headers/recursive-header.cu
+++ b/tests/unit_tests/headers/local_headers/recursive-header.cu
@@ -1,5 +1,4 @@
-// RUN: %run_test hipify "%s" "%t" %hipify_args --local-headers-recursive
-// %clang_args
+// RUN: %run_test hipify "%s" "%t" %hipify_args 1 --local-headers-recursive %clang_args
 
 // CHECK: #include <hip/hip_runtime.h>
 // CHECK-NOT: #include <cuda_runtime.h>

--- a/tests/unit_tests/headers/local_headers/relative/common1.h
+++ b/tests/unit_tests/headers/local_headers/relative/common1.h
@@ -1,4 +1,4 @@
-// RUN: %run_test hipify "%s" "%t" %hipify_args --local-headers-recursive %clang_args
+// RUN: %run_test hipify "%s" "%t" %hipify_args %clang_args
 
 #ifndef COMMON1_H
 #define COMMON1_H

--- a/tests/unit_tests/headers/local_headers/relative/sub/common2.h
+++ b/tests/unit_tests/headers/local_headers/relative/sub/common2.h
@@ -1,4 +1,4 @@
-// RUN: %run_test hipify "%s" "%t" %hipify_args --local-headers-recursive %clang_args
+// RUN: %run_test hipify "%s" "%t" %hipify_args %clang_args
 
 #ifndef COMMON2_H
 #define COMMON2_H

--- a/tests/unit_tests/headers/local_headers/relative_path.cu
+++ b/tests/unit_tests/headers/local_headers/relative_path.cu
@@ -1,4 +1,4 @@
-// RUN: %run_test hipify "%s" "%t" %hipify_args --local-headers %clang_args
+// RUN: %run_test hipify "%s" "%t" %hipify_args %clang_args
 
 // CHECK: #include <hip/hip_runtime.h>
 // CHECK-NOT: #include <cuda_runtime.h>

--- a/tests/unit_tests/headers/local_headers/relative_path.cu
+++ b/tests/unit_tests/headers/local_headers/relative_path.cu
@@ -1,4 +1,4 @@
-// RUN: %run_test hipify "%s" "%t" %hipify_args --local-headers %clang_args
+// RUN: %run_test hipify "%s" "%t" %hipify_args 1 --local-headers %clang_args
 
 // CHECK: #include <hip/hip_runtime.h>
 // CHECK-NOT: #include <cuda_runtime.h>

--- a/tests/unit_tests/headers/local_headers/relative_path.cu
+++ b/tests/unit_tests/headers/local_headers/relative_path.cu
@@ -1,4 +1,4 @@
-// RUN: %run_test hipify "%s" "%t" %hipify_args %clang_args
+// RUN: %run_test hipify "%s" "%t" %hipify_args --local-headers %clang_args
 
 // CHECK: #include <hip/hip_runtime.h>
 // CHECK-NOT: #include <cuda_runtime.h>

--- a/tests/unit_tests/headers/local_headers/shared.h
+++ b/tests/unit_tests/headers/local_headers/shared.h
@@ -1,4 +1,4 @@
-// RUN: %run_test hipify "%s" "%t" %hipify_args --local-headers %clang_args
+// RUN: %run_test hipify "%s" "%t" %hipify_args %clang_args
 #ifndef SHARED_H
 #define SHARED_H
 // CHECK: #include <hip/hip_runtime.h>

--- a/tests/unit_tests/headers/local_headers/shared_dep.h
+++ b/tests/unit_tests/headers/local_headers/shared_dep.h
@@ -1,0 +1,15 @@
+// RUN: %run_test hipify "%s" "%t" %hipify_args %clang_args
+
+#ifndef SHARED_DEP_H
+#define SHARED_DEP_H
+
+// CHECK: #include <hip/hip_runtime.h>
+// CHECK-NOT: #include <cuda_runtime.h>
+#include <cuda_runtime.h>
+
+inline void shared_dep_sync() {
+    // CHECK: hipDeviceSynchronize();
+    cudaDeviceSynchronize();
+}
+
+#endif

--- a/tests/unit_tests/headers/local_headers/shared_header_1.cu
+++ b/tests/unit_tests/headers/local_headers/shared_header_1.cu
@@ -1,4 +1,4 @@
-// RUN: %run_test hipify "%s" "%t" %hipify_args --local-headers %clang_args
+// RUN: %run_test hipify "%s" "%t" %hipify_args %clang_args
 
 // CHECK: #include <hip/hip_runtime.h>
 // CHECK-NOT: #include <cuda_runtime.h>

--- a/tests/unit_tests/headers/local_headers/shared_header_1.cu
+++ b/tests/unit_tests/headers/local_headers/shared_header_1.cu
@@ -1,4 +1,4 @@
-// RUN: %run_test hipify "%s" "%t" %hipify_args --local-headers %clang_args
+// RUN: %run_test hipify "%s" "%t" %hipify_args 1 --local-headers %clang_args
 
 // CHECK: #include <hip/hip_runtime.h>
 // CHECK-NOT: #include <cuda_runtime.h>

--- a/tests/unit_tests/headers/local_headers/shared_header_1.cu
+++ b/tests/unit_tests/headers/local_headers/shared_header_1.cu
@@ -1,4 +1,4 @@
-// RUN: %run_test hipify "%s" "%t" %hipify_args %clang_args
+// RUN: %run_test hipify "%s" "%t" %hipify_args --local-headers %clang_args
 
 // CHECK: #include <hip/hip_runtime.h>
 // CHECK-NOT: #include <cuda_runtime.h>

--- a/tests/unit_tests/headers/local_headers/shared_header_2.cu
+++ b/tests/unit_tests/headers/local_headers/shared_header_2.cu
@@ -1,4 +1,4 @@
-// RUN: %run_test hipify "%s" "%t" %hipify_args --local-headers %clang_args
+// RUN: %run_test hipify "%s" "%t" %hipify_args %clang_args
 
 // CHECK: #include <hip/hip_runtime.h>
 // CHECK-NOT: #include <cuda_runtime.h>

--- a/tests/unit_tests/headers/local_headers/shared_header_2.cu
+++ b/tests/unit_tests/headers/local_headers/shared_header_2.cu
@@ -1,4 +1,4 @@
-// RUN: %run_test hipify "%s" "%t" %hipify_args --local-headers %clang_args
+// RUN: %run_test hipify "%s" "%t" %hipify_args 1 --local-headers %clang_args
 
 // CHECK: #include <hip/hip_runtime.h>
 // CHECK-NOT: #include <cuda_runtime.h>

--- a/tests/unit_tests/headers/local_headers/shared_header_2.cu
+++ b/tests/unit_tests/headers/local_headers/shared_header_2.cu
@@ -1,4 +1,4 @@
-// RUN: %run_test hipify "%s" "%t" %hipify_args %clang_args
+// RUN: %run_test hipify "%s" "%t" %hipify_args --local-headers %clang_args
 
 // CHECK: #include <hip/hip_runtime.h>
 // CHECK-NOT: #include <cuda_runtime.h>

--- a/tests/unit_tests/headers/local_headers/single_header.cu
+++ b/tests/unit_tests/headers/local_headers/single_header.cu
@@ -1,4 +1,4 @@
-// RUN: %run_test hipify "%s" "%t" %hipify_args --local-headers %clang_args
+// RUN: %run_test hipify "%s" "%t" %hipify_args %clang_args
 
 // CHECK: #include <hip/hip_runtime.h>
 // CHECK-NOT: #include <cuda_runtime.h>

--- a/tests/unit_tests/headers/local_headers/single_header.cu
+++ b/tests/unit_tests/headers/local_headers/single_header.cu
@@ -1,4 +1,4 @@
-// RUN: %run_test hipify "%s" "%t" %hipify_args --local-headers %clang_args
+// RUN: %run_test hipify "%s" "%t" %hipify_args 1 --local-headers %clang_args
 
 // CHECK: #include <hip/hip_runtime.h>
 // CHECK-NOT: #include <cuda_runtime.h>

--- a/tests/unit_tests/headers/local_headers/single_header.cu
+++ b/tests/unit_tests/headers/local_headers/single_header.cu
@@ -1,4 +1,4 @@
-// RUN: %run_test hipify "%s" "%t" %hipify_args %clang_args
+// RUN: %run_test hipify "%s" "%t" %hipify_args --local-headers %clang_args
 
 // CHECK: #include <hip/hip_runtime.h>
 // CHECK-NOT: #include <cuda_runtime.h>

--- a/tests/unit_tests/headers/local_headers/single_header.h
+++ b/tests/unit_tests/headers/local_headers/single_header.h
@@ -1,4 +1,4 @@
-// RUN: %run_test hipify "%s" "%t" %hipify_args --local-headers %clang_args
+// RUN: %run_test hipify "%s" "%t" %hipify_args %clang_args
 #ifndef SINGLE_HEADER_H
 #define SINGLE_HEADER_H
 // CHECK: #include <hip/hip_runtime.h>

--- a/tests/unit_tests/headers/local_headers/stress_test.cu
+++ b/tests/unit_tests/headers/local_headers/stress_test.cu
@@ -1,4 +1,4 @@
-// RUN: %run_test hipify "%s" "%t" %hipify_args --local-headers %clang_args
+// RUN: %run_test hipify "%s" "%t" %hipify_args %clang_args
 
 // CHECK: #include <hip/hip_runtime.h>
 // CHECK-NOT: #include <cuda_runtime.h>

--- a/tests/unit_tests/headers/local_headers/stress_test.cu
+++ b/tests/unit_tests/headers/local_headers/stress_test.cu
@@ -1,4 +1,4 @@
-// RUN: %run_test hipify "%s" "%t" %hipify_args --local-headers %clang_args
+// RUN: %run_test hipify "%s" "%t" %hipify_args 1 --local-headers %clang_args
 
 // CHECK: #include <hip/hip_runtime.h>
 // CHECK-NOT: #include <cuda_runtime.h>

--- a/tests/unit_tests/headers/local_headers/stress_test.cu
+++ b/tests/unit_tests/headers/local_headers/stress_test.cu
@@ -1,4 +1,4 @@
-// RUN: %run_test hipify "%s" "%t" %hipify_args %clang_args
+// RUN: %run_test hipify "%s" "%t" %hipify_args --local-headers %clang_args
 
 // CHECK: #include <hip/hip_runtime.h>
 // CHECK-NOT: #include <cuda_runtime.h>

--- a/tests/unit_tests/headers/local_headers/subdir_a/dup_name.h
+++ b/tests/unit_tests/headers/local_headers/subdir_a/dup_name.h
@@ -1,0 +1,15 @@
+// RUN: %run_test hipify "%s" "%t" %hipify_args %clang_args
+
+#ifndef SUBDIR_A_DUP_NAME_H
+#define SUBDIR_A_DUP_NAME_H
+
+// CHECK: #include <hip/hip_runtime.h>
+// CHECK-NOT: #include <cuda_runtime.h>
+#include <cuda_runtime.h>
+
+inline void subdir_a_sync() {
+    // CHECK: hipDeviceSynchronize();
+    cudaDeviceSynchronize();
+}
+
+#endif

--- a/tests/unit_tests/headers/local_headers/subdir_b/dup_name.h
+++ b/tests/unit_tests/headers/local_headers/subdir_b/dup_name.h
@@ -1,0 +1,15 @@
+// RUN: %run_test hipify "%s" "%t" %hipify_args %clang_args
+
+#ifndef SUBDIR_B_DUP_NAME_H
+#define SUBDIR_B_DUP_NAME_H
+
+// CHECK: #include <hip/hip_runtime.h>
+// CHECK-NOT: #include <cuda_runtime.h>
+#include <cuda_runtime.h>
+
+inline void subdir_b_sync() {
+    // CHECK: hipDeviceSynchronize();
+    cudaDeviceSynchronize();
+}
+
+#endif

--- a/tests/unit_tests/headers/local_headers/transitive_child.h
+++ b/tests/unit_tests/headers/local_headers/transitive_child.h
@@ -1,8 +1,11 @@
 #ifndef TRANSITIVE_CHILD_H
 #define TRANSITIVE_CHILD_H
 
+#include <algorithm>
+
 inline void child_sort_alloc(int *data, int n, void **p) {
     std::sort(data, data + n);
+    // CHECK: hipMalloc(p, n * sizeof(int));
     cudaMalloc(p, n * sizeof(int));
 }
 

--- a/tests/unit_tests/headers/local_headers/transitive_child.h
+++ b/tests/unit_tests/headers/local_headers/transitive_child.h
@@ -1,0 +1,9 @@
+#ifndef TRANSITIVE_CHILD_H
+#define TRANSITIVE_CHILD_H
+
+inline void child_sort_alloc(int *data, int n, void **p) {
+    std::sort(data, data + n);
+    cudaMalloc(p, n * sizeof(int));
+}
+
+#endif

--- a/tests/unit_tests/headers/local_headers/transitive_parent.h
+++ b/tests/unit_tests/headers/local_headers/transitive_parent.h
@@ -1,0 +1,15 @@
+#ifndef TRANSITIVE_PARENT_H
+#define TRANSITIVE_PARENT_H
+
+// CHECK: #include <hip/hip_runtime.h>
+// CHECK-NOT: #include <cuda_runtime.h>
+// CHECK: #include "transitive_child.h"
+#include <cuda_runtime.h>
+#include "transitive_child.h"
+
+inline void parent_sync() {
+    // CHECK: hipDeviceSynchronize();
+    cudaDeviceSynchronize();
+}
+
+#endif

--- a/tests/unit_tests/headers/local_headers/transitive_system_include.cu
+++ b/tests/unit_tests/headers/local_headers/transitive_system_include.cu
@@ -1,4 +1,4 @@
-// RUN: %run_test hipify "%s" "%t" %hipify_args --local-headers %clang_args
+// RUN: %run_test hipify "%s" "%t" %hipify_args 1 --local-headers-recursive %clang_args
 
 // CHECK: #include <hip/hip_runtime.h>
 // CHECK-NOT: #include <cuda_runtime.h>

--- a/tests/unit_tests/headers/local_headers/transitive_system_include.cu
+++ b/tests/unit_tests/headers/local_headers/transitive_system_include.cu
@@ -1,0 +1,10 @@
+// RUN: %run_test hipify "%s" "%t" %hipify_args %clang_args
+
+// CHECK: #include <hip/hip_runtime.h>
+// CHECK-NOT: #include <cuda_runtime.h>
+// CHECK: #include "transitive_parent.h"
+#include <cuda_runtime.h>
+#include <algorithm>
+#include "transitive_parent.h"
+
+int main() { return 0; }

--- a/tests/unit_tests/headers/local_headers/transitive_system_include.cu
+++ b/tests/unit_tests/headers/local_headers/transitive_system_include.cu
@@ -1,4 +1,4 @@
-// RUN: %run_test hipify "%s" "%t" %hipify_args %clang_args
+// RUN: %run_test hipify "%s" "%t" %hipify_args --local-headers %clang_args
 
 // CHECK: #include <hip/hip_runtime.h>
 // CHECK-NOT: #include <cuda_runtime.h>

--- a/tests/unit_tests/headers/local_headers/vector_math.h
+++ b/tests/unit_tests/headers/local_headers/vector_math.h
@@ -1,4 +1,4 @@
-// RUN: %run_test hipify "%s" "%t" %hipify_args --local-headers %clang_args
+// RUN: %run_test hipify "%s" "%t" %hipify_args %clang_args
 
 #ifndef VECTOR_MATH_H
 #define VECTOR_MATH_H

--- a/tests/unit_tests/headers/local_headers/vector_math.h
+++ b/tests/unit_tests/headers/local_headers/vector_math.h
@@ -1,0 +1,12 @@
+// RUN: %run_test hipify "%s" "%t" %hipify_args --local-headers %clang_args
+
+#ifndef VECTOR_MATH_H
+#define VECTOR_MATH_H
+
+// CHECK: #include <hip/hip_runtime.h>
+// CHECK-NOT: #include <cuda_runtime.h>
+#include <cuda_runtime.h>
+
+inline __host__ __device__ void dummy_vector_op() { return; }
+
+#endif


### PR DESCRIPTION
## Problem Statement
`hipify-clang` currently only transforms the main source file passed as input. Local (quoted) headers included in the main file remain same as CUDA code. These headers often cannot be hipified individually because they are not self-contained headers which requires types, operators, and definitions from preceding includes in the parent source.

Example: [dxtc.cu](https://github.com/NVIDIA/cuda-samples/blob/master/Samples/5_Domain_Specific/dxtc/dxtc.cu) includes `CudaMath.h`, which uses `float3` operators (`+=`, `*`, `-`) defined in `helper_math.h`. Hipifying `CudaMath.h` alone fails because these operators are unavailable. Similar cases:
- [bodysystemcpu_impl.h](https://github.com/NVIDIA/cuda-samples/blob/master/Samples/5_Domain_Specific/nbody/bodysystemcpu_impl.h)
- [MonteCarlo_reduction.cuh](https://github.com/NVIDIA/cuda-samples/blob/master/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarlo_reduction.cuh)
- [fastWalshTransform_kernel.cuh](https://github.com/NVIDIA/cuda-samples/blob/master/Samples/5_Domain_Specific/fastWalshTransform/fastWalshTransform_kernel.cuh)

## Solution
Two new opt-in flags enable local header hipification:
```
hipify-clang --local-headers main.cu -I ../Common/ 
hipify-clang --local-headers-recursive main.cu -I ../Common/
```

The feature is **experimental** and disabled by default. It will be promoted to default behavior in later release cycles with `--skip-local-headers` as the opt-out fallback.

Supersedes #2275 

## Summary of changes in this PR

### Clang PPCallbacks instead of regex
Include discovery is using Clang's `PPCallbacks::InclusionDirective` via preprocessing pre-pass, not regex. This correctly handles conditional compilation (`#ifdef`), macro-computed includes (`#include MACRO`), compiler search paths (`-I`, `-isystem`), and comments. 

### Fixed Compilation Database fallback
Header files which have no entry in `compile_commands.json` falls back to a `FixedCompilationDatabase` rooted at the main source file's directory so that relative paths resolve correctly.

### Cycle and duplicate detection
A `processed` set prevents re-hipification, and a `queued` set prevents duplicate work-queue entries during recursive traversal.

ToDo work (follow-up PRs):

- [ ] **Warning for non-self-contained headers**: Warn (besides compiler’s error messaging) the user about imposibility to hipify a header file, which is not self-contained.
- [ ] **Folder-level hipification**: Hipify everything in the provided folder.
- [ ] **Promote to default** (add `--skip-local-headers`)
- [ ] **Angle-bracket local header hipification** (`#include <mylib/utils.h>` via `-I`) — #2505
- [ ] **Transitive preceding includes for deeply nested recursive headers** — #2507
