### PR TITLE
[HIPIFY][fix] `LLVM upstream preparations` - Part 4 - `namespace` usage revision

### DIFF
--- a/src/CUDA2HIP_Doc.cpp
+++ b/src/CUDA2HIP_Doc.cpp
@@ -28,14 +28,22 @@ THE SOFTWARE.
 
 namespace doc {
 
-  using namespace std;
-  using namespace llvm;
+  using std::string;
+  using std::map;
+  using std::vector;
+  using std::unique_ptr;
+  using std::ostream;
+  using std::ofstream;
+  using std::stringstream;
+  using std::error_code;
+  using std::make_pair;
+  using std::endl;
 
-  typedef map<unsigned int, StringRef> sectionMap;
-  typedef map<StringRef, hipCounter> functionMap;
+  typedef map<unsigned int, llvm::StringRef> sectionMap;
+  typedef map<llvm::StringRef, hipCounter> functionMap;
   typedef functionMap typeMap;
-  typedef map<StringRef, cudaAPIversions> versionMap;
-  typedef map<StringRef, hipAPIversions> hipVersionMap;
+  typedef map<llvm::StringRef, cudaAPIversions> versionMap;
+  typedef map<llvm::StringRef, hipAPIversions> hipVersionMap;
   typedef map<llvm::StringRef, hipAPIChangedVersions> hipChangedVersionMap;
   typedef map<llvm::StringRef, cudaAPIChangedVersions> cudaChangedVersionMap;
   typedef map<llvm::StringRef, cudaAPIUnsupportedVersions> cudaUnsupportedVersionMap;
@@ -106,7 +114,6 @@ namespace doc {
   const string sMIOPEN_md = sMIOPEN_ + md_ext;
   const string sMIOPEN_csv = sMIOPEN_ + csv_ext;
   const string sCUDNN = "CUDNN";
-
   const string sFFT = "CUFFT_API_supported_by_HIP";
   const string sFFT_md = sFFT + md_ext;
   const string sFFT_csv = sFFT + csv_ext;
@@ -243,15 +250,15 @@ namespace doc {
 
       bool init(docType t) {
         string file = (dir.empty() ? getFileName(t) : dir + "/" + getFileName(t));
-        SmallString<128> tmpFile;
-        EC = sys::fs::createTemporaryFile(file, getExtension(t), tmpFile);
+        llvm::SmallString<128> tmpFile;
+        EC = llvm::sys::fs::createTemporaryFile(file, getExtension(t), tmpFile);
         if (EC) {
-          errs() << "\n" << sHipify << sError << EC.message() << ": " << tmpFile << "\n";
+          llvm::errs() << "\n" << sHipify << sError << EC.message() << ": " << tmpFile << "\n";
           return false;
         }
         files.insert({ t, file });
         tmpFiles.insert({ t, tmpFile.str().str() });
-        streams.insert(make_pair(t, unique_ptr<ostream>(new ofstream(tmpFile.c_str(), ios_base::trunc))));
+        streams.insert(make_pair(t, unique_ptr<ostream>(new ofstream(tmpFile.c_str(), std::ios_base::trunc))));
         return true;
       }
 
@@ -464,12 +471,12 @@ namespace doc {
       bool fini(docType format) {
         streams[format].get()->flush();
         bool bRet = true;
-        EC = sys::fs::copy_file(tmpFiles[format], files[format]);
+        EC = llvm::sys::fs::copy_file(tmpFiles[format], files[format]);
         if (EC) {
-          errs() << "\n" << sHipify << sError << EC.message() << ": while copying " << tmpFiles[format] << " to " << files[format] << "\n";
+          llvm::errs() << "\n" << sHipify << sError << EC.message() << ": while copying " << tmpFiles[format] << " to " << files[format] << "\n";
           bRet = false;
         }
-        if (!SaveTemps) sys::fs::remove(tmpFiles[format]);
+        if (!SaveTemps) llvm::sys::fs::remove(tmpFiles[format]);
         return bRet;
       }
 

--- a/src/HipifyAction.cpp
+++ b/src/HipifyAction.cpp
@@ -35,6 +35,7 @@ THE SOFTWARE.
 #include "CUDA2HIP.h"
 #include "ArgParse.h"
 
+using namespace llvm;
 using namespace hipify;
 
 const std::string sHIP = "HIP";

--- a/src/HipifyAction.h
+++ b/src/HipifyAction.h
@@ -32,7 +32,6 @@ THE SOFTWARE.
 
 namespace ct = clang::tooling;
 namespace mat = clang::ast_matchers;
-using namespace llvm;
 
 /**
   * A FrontendAction that hipifies CUDA programs.
@@ -68,7 +67,7 @@ private:
   clang::SourceLocation firstHeaderLoc;
   clang::SourceLocation pragmaOnceLoc;
   // Rewrite a string literal to refer to hip, not CUDA.
-  void RewriteString(StringRef s, clang::SourceLocation start);
+  void RewriteString(llvm::StringRef s, clang::SourceLocation start);
   // Replace a CUDA identifier with the corresponding hip identifier, if applicable.
   void RewriteToken(const clang::Token &t);
   // Calculate str's SourceLocation in SourceRange sr
@@ -91,12 +90,12 @@ public:
   // Called by the preprocessor for each include directive during the non-raw lexing pass.
   void InclusionDirective(clang::SourceLocation hash_loc,
                           const clang::Token &include_token,
-                          StringRef file_name,
+                          llvm::StringRef file_name,
                           bool is_angled,
                           clang::CharSourceRange filename_range,
                           const clang::FileEntry *file,
-                          StringRef search_path,
-                          StringRef relative_path,
+                          llvm::StringRef search_path,
+                          llvm::StringRef relative_path,
                           const clang::Module *imported);
   // Called by the preprocessor for each pragma directive during the non-raw lexing pass.
   void PragmaDirective(clang::SourceLocation Loc, clang::PragmaIntroducerKind Introducer);
@@ -117,7 +116,7 @@ protected:
   void EndSourceFileAction() override;
   // MatchCallback API entry point. Called by the AST visitor while searching the AST for things we registered an interest for.
   void run(const mat::MatchFinder::MatchResult &Result) override;
-  std::unique_ptr<clang::ASTConsumer> CreateASTConsumer(clang::CompilerInstance &CI, StringRef InFile) override;
+  std::unique_ptr<clang::ASTConsumer> CreateASTConsumer(clang::CompilerInstance &CI, llvm::StringRef InFile) override;
   bool Exclude(const hipCounter &hipToken);
-  void FindAndReplace(StringRef name, clang::SourceLocation sl, const std::map<StringRef, hipCounter> &repMap, bool bReplace = true);
+  void FindAndReplace(llvm::StringRef name, clang::SourceLocation sl, const std::map<llvm::StringRef, hipCounter> &repMap, bool bReplace = true);
 };

--- a/src/LLVMCompat.cpp
+++ b/src/LLVMCompat.cpp
@@ -28,6 +28,8 @@ THE SOFTWARE.
 #include "clang/Lex/PreprocessorOptions.h"
 #include "clang/Frontend/CompilerInstance.h"
 
+using namespace llvm;
+
 const std::string sHipify = "[HIPIFY] ", sConflict = "conflict: ", sError = "error: ", sWarning = "warning: ";
 
 namespace llcompat {

--- a/src/LLVMCompat.h
+++ b/src/LLVMCompat.h
@@ -57,15 +57,13 @@ clang::SourceLocation getEndLoc(const clang::TypeLoc &typeLoc);
 
 void PrintStackTraceOnErrorSignal();
 
-using namespace llvm;
-
 /**
   * Get the replacement map for a given filename in a RefactoringTool.
   *
   * Older LLVM versions don't actually support multiple filenames, so everything all gets
   * smushed together. It is the caller's responsibility to cope with this.
   */
-ct::Replacements &getReplacements(ct::RefactoringTool &Tool, StringRef file);
+ct::Replacements &getReplacements(ct::RefactoringTool &Tool, llvm::StringRef file);
 
 /**
   * Add a Replacement to a Replacements.
@@ -80,7 +78,7 @@ void EnterPreprocessorTokenStream(clang::Preprocessor &_pp,
                                   size_t len,
                                   bool DisableMacroExpansion);
 
-std::error_code real_path(const Twine &path, SmallVectorImpl<char> &output,
+std::error_code real_path(const llvm::Twine &path, llvm::SmallVectorImpl<char> &output,
                           bool expand_tilde = false);
 
 bool pragma_once_outside_header();
@@ -92,9 +90,9 @@ bool CheckCompatibility();
 clang::SourceLocation getEndOfExpansionRangeForLoc(const clang::SourceManager &SM, const clang::SourceLocation &loc);
 
 #if LLVM_VERSION_MAJOR >= 12
-  typedef MemoryBufferRef Memory_Buffer;
+  typedef llvm::MemoryBufferRef Memory_Buffer;
 #else
-  typedef const MemoryBuffer *Memory_Buffer;
+  typedef const llvm::MemoryBuffer *Memory_Buffer;
 #endif
 
 Memory_Buffer getMemoryBuffer(const clang::SourceManager &SM);

--- a/src/LocalHeader.cpp
+++ b/src/LocalHeader.cpp
@@ -16,13 +16,12 @@
 using namespace clang;
 using namespace clang::tooling;
 using namespace llvm;
-using namespace std;
 
 static std::string normalizeSmallStringPath(SmallString<256> &p) {
-  llvm::sys::path::remove_dots(p, true);
+  sys::path::remove_dots(p, true);
 
   SmallString<256> realBuf;
-  std::error_code ec = llvm::sys::fs::real_path(p, realBuf);
+  std::error_code ec = sys::fs::real_path(p, realBuf);
   if (!ec) {
     return std::string(realBuf.str());
   }
@@ -34,12 +33,12 @@ static bool pathExists(const std::string &p) {
   SmallString<256> in(p.begin(), p.end());
 
   SmallString<256> realBuf;
-  std::error_code ec = llvm::sys::fs::real_path(in, realBuf);
+  std::error_code ec = sys::fs::real_path(in, realBuf);
   if (!ec) return true;
 
   SmallString<256> norm = in;
-  llvm::sys::path::remove_dots(norm, true);
-  return llvm::sys::fs::exists(norm);
+  sys::path::remove_dots(norm, true);
+  return sys::fs::exists(norm);
 }
 
 namespace {
@@ -47,7 +46,7 @@ namespace {
       R"(^\s*#\s*include\s*\"([^\"\n]+)\"\s*(?://.*)?$)", std::regex::ECMAScript);
 
   bool readFile(const std::string &path, std::string &out) {
-    auto MBOrErr = llvm::MemoryBuffer::getFile(path);
+    auto MBOrErr = MemoryBuffer::getFile(path);
     if (!MBOrErr) return false;
     out = MBOrErr->get()->getBuffer().str();
     return true;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -55,6 +55,8 @@ THE SOFTWARE.
 
 constexpr auto DEBUG_TYPE = "cuda2hip";
 
+using namespace llvm;
+
 namespace ct = clang::tooling;
 
 void cleanupHipifyOptions(std::vector<const char*> &args) {


### PR DESCRIPTION
Addresses `using namespace` violations in headers and main source(.cpp) files to match with LLVM coding standards. 

- Removed `using namespace llvm;`, `using namespace llvm;` and used `llvm::`, `std::` in header files.
- Added `using namespace llvm;` in main source(.cpp) files