### PR TITLE
[HIPIFY] Add LLVM lib dir to hipify-clang RPATH

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -256,20 +256,37 @@ if (NOT HIPIFY_CLANG_TESTS_ONLY)
     # hipify-clang must therefore be able to find libLLVM at runtime, wherever
     # the consumed LLVM package installed it, hence deriving the RPATH below
     # from LLVM_LIBRARY_DIRS instead of assuming a fixed layout.
-    set(HIPIFY_RPATH_DIRS "\\$ORIGIN/../lib" "\\$ORIGIN/../lib/llvm/lib")
-    foreach(_llvm_lib_dir ${LLVM_LIBRARY_DIRS})
+    #
+    # $ORIGIN/../lib covers the flat layout; the versioned ROCm layout installs
+    # the binary in core-X.Y/bin and libLLVM in core-X.Y/lib/llvm/lib.
+    set(HIPIFY_INSTALL_RPATH "\$ORIGIN/../lib" "\$ORIGIN/../lib/llvm/lib")
+    foreach(_llvm_lib_dir IN LISTS LLVM_LIBRARY_DIRS)
       file(RELATIVE_PATH _llvm_lib_rel "${CMAKE_INSTALL_PREFIX}" "${_llvm_lib_dir}")
-      if(_llvm_lib_rel AND NOT IS_ABSOLUTE "${_llvm_lib_rel}" AND NOT _llvm_lib_rel MATCHES "^\\.\\.")
-        list(APPEND HIPIFY_RPATH_DIRS "\\$ORIGIN/../${_llvm_lib_rel}")
+      if(NOT _llvm_lib_rel OR IS_ABSOLUTE "${_llvm_lib_rel}" OR _llvm_lib_rel MATCHES "^\\.\\.")
+        # Outside CMAKE_INSTALL_PREFIX, so deliberately left out of the install
+        # RPATH: an absolute build-machine path must not be baked into a
+        # redistributable binary. The build-tree binary still resolves libLLVM
+        # through the BUILD_RPATH that llvm_setup_rpath() derives from
+        # LLVM_LIBRARY_DIR for exactly this out-of-prefix case.
+        message(STATUS "   - LLVM lib dir outside install prefix, omitted from hipify-clang install RPATH: ${_llvm_lib_dir}")
+      elseif(_llvm_lib_rel MATCHES ":")
+        # ':' separates entries in an ELF RPATH and cannot be escaped.
+        message(WARNING "LLVM lib dir contains ':' and cannot be represented in an RPATH, omitted from hipify-clang install RPATH: ${_llvm_lib_dir}")
+      else()
+        list(APPEND HIPIFY_INSTALL_RPATH "\$ORIGIN/../${_llvm_lib_rel}")
       endif()
     endforeach()
-    list(REMOVE_DUPLICATES HIPIFY_RPATH_DIRS)
-    list(JOIN HIPIFY_RPATH_DIRS ":" HIPIFY_RPATH)
+    list(REMOVE_DUPLICATES HIPIFY_INSTALL_RPATH)
 
-    # Get rid of any RPATH definations already.
-    set_target_properties(hipify-clang PROPERTIES INSTALL_RPATH "")
-    # Set RPATH for the binary.
-    set_target_properties(hipify-clang PROPERTIES LINK_FLAGS "-Wl,--enable-new-dtags -Wl,--rpath,${HIPIFY_RPATH}" )
+    # Set the RPATH via INSTALL_RPATH rather than a hand-built LINK_FLAGS
+    # string. LINK_FLAGS is a single unquoted string, so any path containing a
+    # space would split the -Wl,--rpath argument, and assigning it here would
+    # also discard the -Wl,-rpath-link (GNU ld) and -Wl,-z,origin (FreeBSD)
+    # flags that llvm_setup_rpath() appended from add_llvm_executable().
+    # INSTALL_RPATH is a real list that CMake quotes and joins itself, and
+    # setting it replaces the value llvm_setup_rpath() had installed.
+    set_target_properties(hipify-clang PROPERTIES INSTALL_RPATH "${HIPIFY_INSTALL_RPATH}")
+    target_link_options(hipify-clang PRIVATE "LINKER:--enable-new-dtags")
 
     set(CPACK_PACKAGING_INSTALL_PREFIX "/opt/rocm" CACHE PATH "HIP Package Installation Path")
     set(BUILD_DIR ${CMAKE_CURRENT_BINARY_DIR}/packages/hipify-clang)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -251,7 +251,7 @@ if (NOT HIPIFY_CLANG_TESTS_ONLY)
     # Get rid of any RPATH definations already.
     set_target_properties(hipify-clang PROPERTIES INSTALL_RPATH "")
     # Set RPATH for the binary.
-    set_target_properties(hipify-clang PROPERTIES LINK_FLAGS "-Wl,--enable-new-dtags -Wl,--rpath,\\$ORIGIN/../lib" )
+    set_target_properties(hipify-clang PROPERTIES LINK_FLAGS "-Wl,--enable-new-dtags -Wl,--rpath,\\$ORIGIN/../lib:\\$ORIGIN/../lib/llvm/lib" )
 
     set(CPACK_PACKAGING_INSTALL_PREFIX "/opt/rocm" CACHE PATH "HIP Package Installation Path")
     set(BUILD_DIR ${CMAKE_CURRENT_BINARY_DIR}/packages/hipify-clang)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -248,10 +248,28 @@ if (NOT HIPIFY_CLANG_TESTS_ONLY)
   endif()
 
   if(UNIX)
+    # hipify-clang cannot be statically linked against LLVM/clang on platforms
+    # (e.g. TheRock's Linux build) where LLVM_LINK_LLVM_DYLIB=ON: clang's static
+    # libraries carry a transitive dependency on libLLVM in that configuration,
+    # so mixing them with statically-linked LLVM components causes ODR
+    # violations ("duplicate cl::opt registered") at runtime - see #1840/#1873.
+    # hipify-clang must therefore be able to find libLLVM at runtime, wherever
+    # the consumed LLVM package installed it, hence deriving the RPATH below
+    # from LLVM_LIBRARY_DIRS instead of assuming a fixed layout.
+    set(HIPIFY_RPATH_DIRS "\\$ORIGIN/../lib" "\\$ORIGIN/../lib/llvm/lib")
+    foreach(_llvm_lib_dir ${LLVM_LIBRARY_DIRS})
+      file(RELATIVE_PATH _llvm_lib_rel "${CMAKE_INSTALL_PREFIX}" "${_llvm_lib_dir}")
+      if(_llvm_lib_rel AND NOT IS_ABSOLUTE "${_llvm_lib_rel}" AND NOT _llvm_lib_rel MATCHES "^\\.\\.")
+        list(APPEND HIPIFY_RPATH_DIRS "\\$ORIGIN/../${_llvm_lib_rel}")
+      endif()
+    endforeach()
+    list(REMOVE_DUPLICATES HIPIFY_RPATH_DIRS)
+    list(JOIN HIPIFY_RPATH_DIRS ":" HIPIFY_RPATH)
+
     # Get rid of any RPATH definations already.
     set_target_properties(hipify-clang PROPERTIES INSTALL_RPATH "")
     # Set RPATH for the binary.
-    set_target_properties(hipify-clang PROPERTIES LINK_FLAGS "-Wl,--enable-new-dtags -Wl,--rpath,\\$ORIGIN/../lib:\\$ORIGIN/../lib/llvm/lib" )
+    set_target_properties(hipify-clang PROPERTIES LINK_FLAGS "-Wl,--enable-new-dtags -Wl,--rpath,${HIPIFY_RPATH}" )
 
     set(CPACK_PACKAGING_INSTALL_PREFIX "/opt/rocm" CACHE PATH "HIP Package Installation Path")
     set(BUILD_DIR ${CMAKE_CURRENT_BINARY_DIR}/packages/hipify-clang)


### PR DESCRIPTION
Fixes #2704.

## Problem

`hipify-clang` from the ROCm 7.14 packages cannot start, because its `RUNPATH` does not include the directory that actually ships `libLLVM`:

```
$ hipify-clang --version
hipify-clang: error while loading shared libraries: libLLVM.so.23.0git: cannot open shared object file: No such file or directory

$ readelf -d /opt/rocm/core-7.14/bin/hipify-clang | grep RUNPATH
 0x000000000000001d (RUNPATH)  Library runpath: [$ORIGIN/../lib]

$ find /opt/rocm -name 'libLLVM.so.23.0git'
/opt/rocm/core-7.14/lib/llvm/lib/libLLVM.so.23.0git
```

`$ORIGIN/../lib` resolves to `<prefix>/lib`, but in the versioned ROCm layout LLVM is installed one level deeper under `<prefix>/lib/llvm/lib`. `/opt/rocm/lib` is also not registered with the dynamic loader (ROCm/TheRock#6716), so there is no fallback and the failure is unconditional on a stock install.

## Change

Append `$ORIGIN/../lib/llvm/lib` to the RPATH. The original entry is kept first, so a flat layout that installs `libLLVM` directly into `<prefix>/lib` continues to resolve exactly as before.

## Test

Building HIPIFY needs a full LLVM/Clang dev tree, so I verified the RPATH mechanism directly by reproducing the install layout (`bin/`, `lib/`, `lib/llvm/lib/`) and linking a binary against a stand-in library placed where `libLLVM` actually ships:

| case | RPATH | result |
|---|---|---|
| current upstream | `$ORIGIN/../lib` | fails — reproduces the reported error |
| this PR | `$ORIGIN/../lib:$ORIGIN/../lib/llvm/lib` | resolves with no `LD_LIBRARY_PATH` |
| flat layout regression guard | `$ORIGIN/../lib:$ORIGIN/../lib/llvm/lib`, lib in `../lib` | still resolves |

3 passed, 0 failed. The first row is a control: it must keep failing, otherwise the test would be vacuous.

Independently, adding only that directory to the search path is sufficient to make the shipped binary work:

```
$ LD_LIBRARY_PATH=/opt/rocm/core-7.14/lib/llvm/lib hipify-clang --version
AMD LLVM version 23.0.0git
  Optimized build.
```

## Environment

Ubuntu 26.04, ROCm 7.14.0~pre3 (`amdrocm-hipify7.14`) from `repo.radeon.com/rocmradeon/apt/26.13`, gfx1100.

## Note

Opened as a draft. `hipify-perl` is unaffected (Perl script, no shared-library dependency). Related earlier fixes in this area: #678 and #1959.
