### PR TITLE
[HIPIFY][HIP][7.2][RCCL][7.0.2.2][LCOMPILER-2603][backport] `CU_MEM_LOCATION_TYPE_HOST`, `CU_MEM_LOCATION_TYPE_HOST_NUMA`, and `CU_DEVICE_ATTRIBUTE_HOST_NUMA_ID` support

### DIFF
--- a/bin/hipify-perl
+++ b/bin/hipify-perl
@@ -8514,6 +8514,7 @@ sub simpleSubstitutions {
     subst("CU_DEVICE_ATTRIBUTE_GPU_DIRECT_RDMA_WITH_CUDA_VMM_SUPPORTED", "hipDeviceAttributeGPUDirectRDMAWithHipVMMSupported", "numeric_literal");
     subst("CU_DEVICE_ATTRIBUTE_GPU_OVERLAP", "hipDeviceAttributeAsyncEngineCount", "numeric_literal");
     subst("CU_DEVICE_ATTRIBUTE_HOST_NATIVE_ATOMIC_SUPPORTED", "hipDeviceAttributeHostNativeAtomicSupported", "numeric_literal");
+    subst("CU_DEVICE_ATTRIBUTE_HOST_NUMA_ID", "hipDeviceAttributeHostNumaId", "numeric_literal");
     subst("CU_DEVICE_ATTRIBUTE_HOST_REGISTER_SUPPORTED", "hipDeviceAttributeHostRegisterSupported", "numeric_literal");
     subst("CU_DEVICE_ATTRIBUTE_INTEGRATED", "hipDeviceAttributeIntegrated", "numeric_literal");
     subst("CU_DEVICE_ATTRIBUTE_KERNEL_EXEC_TIMEOUT", "hipDeviceAttributeKernelExecTimeout", "numeric_literal");
@@ -8769,6 +8770,8 @@ sub simpleSubstitutions {
     subst("CU_MEM_HANDLE_TYPE_WIN32", "hipMemHandleTypeWin32", "numeric_literal");
     subst("CU_MEM_HANDLE_TYPE_WIN32_KMT", "hipMemHandleTypeWin32Kmt", "numeric_literal");
     subst("CU_MEM_LOCATION_TYPE_DEVICE", "hipMemLocationTypeDevice", "numeric_literal");
+    subst("CU_MEM_LOCATION_TYPE_HOST", "hipMemLocationTypeHost", "numeric_literal");
+    subst("CU_MEM_LOCATION_TYPE_HOST_NUMA", "hipMemLocationTypeHostNuma", "numeric_literal");
     subst("CU_MEM_LOCATION_TYPE_INVALID", "hipMemLocationTypeInvalid", "numeric_literal");
     subst("CU_MEM_OPERATION_TYPE_MAP", "hipMemOperationTypeMap", "numeric_literal");
     subst("CU_MEM_OPERATION_TYPE_UNMAP", "hipMemOperationTypeUnmap", "numeric_literal");
@@ -8918,6 +8921,7 @@ sub simpleSubstitutions {
     subst("cudaDevAttrGlobalMemoryBusWidth", "hipDeviceAttributeMemoryBusWidth", "numeric_literal");
     subst("cudaDevAttrGpuOverlap", "hipDeviceAttributeAsyncEngineCount", "numeric_literal");
     subst("cudaDevAttrHostNativeAtomicSupported", "hipDeviceAttributeHostNativeAtomicSupported", "numeric_literal");
+    subst("cudaDevAttrHostNumaId", "hipDeviceAttributeHostNumaId", "numeric_literal");
     subst("cudaDevAttrHostRegisterSupported", "hipDeviceAttributeHostRegisterSupported", "numeric_literal");
     subst("cudaDevAttrIntegrated", "hipDeviceAttributeIntegrated", "numeric_literal");
     subst("cudaDevAttrIsMultiGpuBoard", "hipDeviceAttributeIsMultiGpuBoard", "numeric_literal");
@@ -9197,6 +9201,8 @@ sub simpleSubstitutions {
     subst("cudaMemHandleTypeWin32", "hipMemHandleTypeWin32", "numeric_literal");
     subst("cudaMemHandleTypeWin32Kmt", "hipMemHandleTypeWin32Kmt", "numeric_literal");
     subst("cudaMemLocationTypeDevice", "hipMemLocationTypeDevice", "numeric_literal");
+    subst("cudaMemLocationTypeHost", "hipMemLocationTypeHost", "numeric_literal");
+    subst("cudaMemLocationTypeHostNuma", "hipMemLocationTypeHostNuma", "numeric_literal");
     subst("cudaMemLocationTypeInvalid", "hipMemLocationTypeInvalid", "numeric_literal");
     subst("cudaMemPoolAttrReleaseThreshold", "hipMemPoolAttrReleaseThreshold", "numeric_literal");
     subst("cudaMemPoolAttrReservedMemCurrent", "hipMemPoolAttrReservedMemCurrent", "numeric_literal");
@@ -11308,8 +11314,6 @@ sub warnRemovedFunctions {
     "cudaMemPrefetchAsync_v2",
     "cudaMemPoolCreateUsageHwDecompress",
     "cudaMemLocationTypeHostNumaCurrent",
-    "cudaMemLocationTypeHostNuma",
-    "cudaMemLocationTypeHost",
     "cudaMemHandleTypeFabric",
     "cudaMemFabricHandle_t",
     "cudaMemFabricHandle_st",
@@ -11711,7 +11715,6 @@ sub warnRemovedFunctions {
     "cudaDevAttrHostRegisterReadOnlySupported",
     "cudaDevAttrHostNumaMultinodeIpcSupported",
     "cudaDevAttrHostNumaMemoryPoolsSupported",
-    "cudaDevAttrHostNumaId",
     "cudaDevAttrGpuPciSubsystemId",
     "cudaDevAttrGpuPciDeviceId",
     "cudaDevAttrGPUDirectRDMAWritesOrdering",
@@ -12551,8 +12554,6 @@ sub warnRemovedFunctions {
     "CU_MEM_POOL_CREATE_USAGE_HW_DECOMPRESS",
     "CU_MEM_LOCATION_TYPE_MAX",
     "CU_MEM_LOCATION_TYPE_HOST_NUMA_CURRENT",
-    "CU_MEM_LOCATION_TYPE_HOST_NUMA",
-    "CU_MEM_LOCATION_TYPE_HOST",
     "CU_MEM_HANDLE_TYPE_MAX",
     "CU_MEM_HANDLE_TYPE_FABRIC",
     "CU_MEM_DECOMPRESS_UNSUPPORTED",
@@ -12783,7 +12784,6 @@ sub warnRemovedFunctions {
     "CU_DEVICE_ATTRIBUTE_HOST_NUMA_VIRTUAL_MEMORY_MANAGEMENT_SUPPORTED",
     "CU_DEVICE_ATTRIBUTE_HOST_NUMA_MULTINODE_IPC_SUPPORTED",
     "CU_DEVICE_ATTRIBUTE_HOST_NUMA_MEMORY_POOLS_SUPPORTED",
-    "CU_DEVICE_ATTRIBUTE_HOST_NUMA_ID",
     "CU_DEVICE_ATTRIBUTE_HANDLE_TYPE_WIN32_KMT_HANDLE_SUPPORTED",
     "CU_DEVICE_ATTRIBUTE_HANDLE_TYPE_WIN32_HANDLE_SUPPORTED",
     "CU_DEVICE_ATTRIBUTE_HANDLE_TYPE_POSIX_FILE_DESCRIPTOR_SUPPORTED",

--- a/docs/reference/tables/CUDA_Driver_API_functions_supported_by_HIP.md
+++ b/docs/reference/tables/CUDA_Driver_API_functions_supported_by_HIP.md
@@ -432,7 +432,7 @@
 |`CU_DEVICE_ATTRIBUTE_HANDLE_TYPE_WIN32_HANDLE_SUPPORTED`|10.2| | | | | | | | | |
 |`CU_DEVICE_ATTRIBUTE_HANDLE_TYPE_WIN32_KMT_HANDLE_SUPPORTED`|10.2| | | | | | | | | |
 |`CU_DEVICE_ATTRIBUTE_HOST_NATIVE_ATOMIC_SUPPORTED`|8.0| | | |`hipDeviceAttributeHostNativeAtomicSupported`|4.3.0| | | | |
-|`CU_DEVICE_ATTRIBUTE_HOST_NUMA_ID`|12.2| | | | | | | | | |
+|`CU_DEVICE_ATTRIBUTE_HOST_NUMA_ID`|12.2| | | |`hipDeviceAttributeHostNumaId`|7.2.0| | | | |
 |`CU_DEVICE_ATTRIBUTE_HOST_NUMA_MEMORY_POOLS_SUPPORTED`|12.9| | | | | | | | | |
 |`CU_DEVICE_ATTRIBUTE_HOST_NUMA_MULTINODE_IPC_SUPPORTED`|12.8| | | | | | | | | |
 |`CU_DEVICE_ATTRIBUTE_HOST_NUMA_VIRTUAL_MEMORY_MANAGEMENT_SUPPORTED`|12.9| | | | | | | | | |
@@ -934,8 +934,8 @@
 |`CU_MEM_HANDLE_TYPE_WIN32`|10.2| | | |`hipMemHandleTypeWin32`|5.2.0| | | | |
 |`CU_MEM_HANDLE_TYPE_WIN32_KMT`|10.2| | | |`hipMemHandleTypeWin32Kmt`|5.2.0| | | | |
 |`CU_MEM_LOCATION_TYPE_DEVICE`|10.2| | | |`hipMemLocationTypeDevice`|5.2.0| | | | |
-|`CU_MEM_LOCATION_TYPE_HOST`|12.2| | | | | | | | | |
-|`CU_MEM_LOCATION_TYPE_HOST_NUMA`|12.2| | | | | | | | | |
+|`CU_MEM_LOCATION_TYPE_HOST`|12.2| | | |`hipMemLocationTypeHost`|7.1.0| | | | |
+|`CU_MEM_LOCATION_TYPE_HOST_NUMA`|12.2| | | |`hipMemLocationTypeHostNuma`|7.1.0| | | | |
 |`CU_MEM_LOCATION_TYPE_HOST_NUMA_CURRENT`|12.2| | | | | | | | | |
 |`CU_MEM_LOCATION_TYPE_INVALID`|10.2| | | |`hipMemLocationTypeInvalid`|5.2.0| | | | |
 |`CU_MEM_LOCATION_TYPE_MAX`|10.2| | | | | | | | | |

--- a/docs/reference/tables/CUDA_Runtime_API_functions_supported_by_HIP.md
+++ b/docs/reference/tables/CUDA_Runtime_API_functions_supported_by_HIP.md
@@ -823,7 +823,7 @@
 |`cudaDevAttrGpuPciDeviceId`|12.8| | | | | | | | | |
 |`cudaDevAttrGpuPciSubsystemId`|12.8| | | | | | | | | |
 |`cudaDevAttrHostNativeAtomicSupported`|8.0| | | |`hipDeviceAttributeHostNativeAtomicSupported`|4.3.0| | | | |
-|`cudaDevAttrHostNumaId`|12.2| | | | | | | | | |
+|`cudaDevAttrHostNumaId`|12.2| | | |`hipDeviceAttributeHostNumaId`|7.2.0| | | | |
 |`cudaDevAttrHostNumaMemoryPoolsSupported`|12.9| | | | | | | | | |
 |`cudaDevAttrHostNumaMultinodeIpcSupported`|12.8| | | | | | | | | |
 |`cudaDevAttrHostRegisterReadOnlySupported`|11.1| | | | | | | | | |
@@ -1550,8 +1550,8 @@
 |`cudaMemLocation`|11.2| | | |`hipMemLocation`|5.2.0| | | | |
 |`cudaMemLocationType`|11.2| | | |`hipMemLocationType`|5.2.0| | | | |
 |`cudaMemLocationTypeDevice`|11.2| | | |`hipMemLocationTypeDevice`|5.2.0| | | | |
-|`cudaMemLocationTypeHost`|12.2| | | | | | | | | |
-|`cudaMemLocationTypeHostNuma`|12.2| | | | | | | | | |
+|`cudaMemLocationTypeHost`|12.2| | | |`hipMemLocationTypeHost`|7.1.0| | | | |
+|`cudaMemLocationTypeHostNuma`|12.2| | | |`hipMemLocationTypeHostNuma`|7.1.0| | | | |
 |`cudaMemLocationTypeHostNumaCurrent`|12.2| | | | | | | | | |
 |`cudaMemLocationTypeInvalid`|11.2| | | |`hipMemLocationTypeInvalid`|5.2.0| | | | |
 |`cudaMemPoolAttr`|11.2| | | |`hipMemPoolAttr`|5.2.0| | | | |

--- a/src/CUDA2HIP_Driver_API_types.cpp
+++ b/src/CUDA2HIP_Driver_API_types.cpp
@@ -1014,7 +1014,7 @@ const std::map<llvm::StringRef, hipCounter> CUDA_DRIVER_TYPE_NAME_MAP {
   // cudaDevAttrMpsEnabled
   {"CU_DEVICE_ATTRIBUTE_MPS_ENABLED",                                  {"hipDeviceAttributeMpsEnables",                             "", CONV_NUMERIC_LITERAL, API_DRIVER, SEC::DATA_TYPES, HIP_UNSUPPORTED}}, // 133
   // cudaDevAttrHostNumaId
-  {"CU_DEVICE_ATTRIBUTE_HOST_NUMA_ID",                                 {"hipDeviceAttributeHostNumaId",                             "", CONV_NUMERIC_LITERAL, API_DRIVER, SEC::DATA_TYPES, HIP_UNSUPPORTED}}, // 134
+  {"CU_DEVICE_ATTRIBUTE_HOST_NUMA_ID",                                 {"hipDeviceAttributeHostNumaId",                             "", CONV_NUMERIC_LITERAL, API_DRIVER, SEC::DATA_TYPES}}, // 134
   // cudaDevAttrD3D12CigSupported
   {"CU_DEVICE_ATTRIBUTE_D3D12_CIG_SUPPORTED",                          {"hipDeviceAttributeD3D12CigSupported",                      "", CONV_NUMERIC_LITERAL, API_DRIVER, SEC::DATA_TYPES, HIP_UNSUPPORTED}}, // 135
   //
@@ -2233,9 +2233,9 @@ const std::map<llvm::StringRef, hipCounter> CUDA_DRIVER_TYPE_NAME_MAP {
   // cudaMemLocationTypeDevice
   {"CU_MEM_LOCATION_TYPE_DEVICE",                                      {"hipMemLocationTypeDevice",                                 "", CONV_NUMERIC_LITERAL, API_DRIVER, SEC::DATA_TYPES}}, // 0x1
   // cudaMemLocationTypeHost
-  {"CU_MEM_LOCATION_TYPE_HOST",                                        {"hipMemLocationTypeHost",                                   "", CONV_NUMERIC_LITERAL, API_DRIVER, SEC::DATA_TYPES, HIP_UNSUPPORTED}}, // 0x2
+  {"CU_MEM_LOCATION_TYPE_HOST",                                        {"hipMemLocationTypeHost",                                   "", CONV_NUMERIC_LITERAL, API_DRIVER, SEC::DATA_TYPES}}, // 0x2
   // cudaMemLocationTypeHostNuma
-  {"CU_MEM_LOCATION_TYPE_HOST_NUMA",                                   {"hipMemLocationTypeHostNuma",                               "", CONV_NUMERIC_LITERAL, API_DRIVER, SEC::DATA_TYPES, HIP_UNSUPPORTED}}, // 0x3
+  {"CU_MEM_LOCATION_TYPE_HOST_NUMA",                                   {"hipMemLocationTypeHostNuma",                               "", CONV_NUMERIC_LITERAL, API_DRIVER, SEC::DATA_TYPES}}, // 0x3
   // cudaMemLocationTypeHostNumaCurrent
   {"CU_MEM_LOCATION_TYPE_HOST_NUMA_CURRENT",                           {"hipMemLocationTypeHostNumaCurrent",                        "", CONV_NUMERIC_LITERAL, API_DRIVER, SEC::DATA_TYPES, HIP_UNSUPPORTED}}, // 0x4
   // no analogue
@@ -4746,6 +4746,7 @@ const std::map<llvm::StringRef, hipAPIversions> HIP_DRIVER_TYPE_NAME_VER_MAP {
   {"hipMemRangeHandleTypeMax",                                         {HIP_7000, HIP_0,    HIP_0,  HIP_LATEST}},
   {"hipMemRangeFlags",                                                 {HIP_7000, HIP_0,    HIP_0,  HIP_LATEST}},
   {"hipMemRangeFlagDmaBufMappingTypePcie",                             {HIP_7000, HIP_0,    HIP_0,  HIP_LATEST}},
+  {"hipDeviceAttributeHostNumaId",                                     {HIP_7020, HIP_0,    HIP_0   }},
   {"hipDeviceAttributeDmaBufSupported",                                {HIP_7120, HIP_0,    HIP_0   }},
   {"hipDeviceAttributeGPUDirectRDMAWithHipVMMSupported",               {HIP_7130, HIP_0,    HIP_0   }},
   {"hipStreamWriteValueDefault",                                       {HIP_7130, HIP_0,    HIP_0   }},

--- a/src/CUDA2HIP_Runtime_API_types.cpp
+++ b/src/CUDA2HIP_Runtime_API_types.cpp
@@ -683,7 +683,7 @@ const std::map<llvm::StringRef, hipCounter> CUDA_RUNTIME_TYPE_NAME_MAP {
   // CU_DEVICE_ATTRIBUTE_MPS_ENABLED
   {"cudaDevAttrMpsEnabled",                                            {"hipDeviceAttributeMpsEnables",                             "", CONV_NUMERIC_LITERAL, API_RUNTIME, SEC::DATA_TYPES, HIP_UNSUPPORTED}}, // 133
   // CU_DEVICE_ATTRIBUTE_HOST_NUMA_ID
-  {"cudaDevAttrHostNumaId",                                            {"hipDeviceAttributeHostNumaId",                             "", CONV_NUMERIC_LITERAL, API_RUNTIME, SEC::DATA_TYPES, HIP_UNSUPPORTED}}, // 134
+  {"cudaDevAttrHostNumaId",                                            {"hipDeviceAttributeHostNumaId",                             "", CONV_NUMERIC_LITERAL, API_RUNTIME, SEC::DATA_TYPES}}, // 134
   // CU_DEVICE_ATTRIBUTE_D3D12_CIG_SUPPORTED
   {"cudaDevAttrD3D12CigSupported",                                     {"hipDeviceAttributeD3D12CigSupported",                      "", CONV_NUMERIC_LITERAL, API_RUNTIME, SEC::DATA_TYPES, HIP_UNSUPPORTED}}, // 135
   // CU_DEVICE_ATTRIBUTE_VULKAN_CIG_SUPPORTED
@@ -1816,9 +1816,9 @@ const std::map<llvm::StringRef, hipCounter> CUDA_RUNTIME_TYPE_NAME_MAP {
   // CU_MEM_LOCATION_TYPE_DEVICE
   {"cudaMemLocationTypeDevice",                                        {"hipMemLocationTypeDevice",                                 "", CONV_NUMERIC_LITERAL, API_RUNTIME, SEC::DATA_TYPES}}, // 1
   // CU_MEM_LOCATION_TYPE_HOST
-  {"cudaMemLocationTypeHost",                                          {"hipMemLocationTypeHost",                                   "", CONV_NUMERIC_LITERAL, API_RUNTIME, SEC::DATA_TYPES, HIP_UNSUPPORTED}}, // 2
+  {"cudaMemLocationTypeHost",                                          {"hipMemLocationTypeHost",                                   "", CONV_NUMERIC_LITERAL, API_RUNTIME, SEC::DATA_TYPES}}, // 2
   // CU_MEM_LOCATION_TYPE_HOST_NUMA
-  {"cudaMemLocationTypeHostNuma",                                      {"hipMemLocationTypeHostNuma",                               "", CONV_NUMERIC_LITERAL, API_RUNTIME, SEC::DATA_TYPES, HIP_UNSUPPORTED}}, // 3
+  {"cudaMemLocationTypeHostNuma",                                      {"hipMemLocationTypeHostNuma",                               "", CONV_NUMERIC_LITERAL, API_RUNTIME, SEC::DATA_TYPES}}, // 3
   // CU_MEM_LOCATION_TYPE_HOST_NUMA_CURRENT
   {"cudaMemLocationTypeHostNumaCurrent",                               {"hipMemLocationTypeHostNumaCurrent",                        "", CONV_NUMERIC_LITERAL, API_RUNTIME, SEC::DATA_TYPES, HIP_UNSUPPORTED}}, // 4
 
@@ -3552,5 +3552,8 @@ const std::map<llvm::StringRef, hipAPIversions> HIP_RUNTIME_TYPE_NAME_VER_MAP {
   {"hipLaunchAttribute",                                               {HIP_7000, HIP_0,    HIP_0,  HIP_LATEST}},
   {"hipLaunchConfig_st",                                               {HIP_7000, HIP_0,    HIP_0,  HIP_LATEST}},
   {"hipLaunchConfig_t",                                                {HIP_7000, HIP_0,    HIP_0,  HIP_LATEST}},
+  {"hipMemLocationTypeHost",                                           {HIP_7010, HIP_0,    HIP_0   }},
+  {"hipMemLocationTypeHostNuma",                                       {HIP_7010, HIP_0,    HIP_0   }},
+  {"hipDeviceAttributeHostNumaId",                                     {HIP_7020, HIP_0,    HIP_0   }},
   {"hipErrorInvalidClusterSize",                                       {HIP_7130, HIP_0,    HIP_0   }},
 };

--- a/src/Statistics.cpp
+++ b/src/Statistics.cpp
@@ -656,6 +656,8 @@ std::string Statistics::getHipVersion(const hipVersions &ver) {
     case HIP_6030: return "6.3.0";
     case HIP_6040: return "6.4.0";
     case HIP_7000: return "7.0.0";
+    case HIP_7010: return "7.1.0";
+    case HIP_7020: return "7.2.0";
     case HIP_7120: return "7.12.0";
     case HIP_7130: return "7.13.0";
   }

--- a/src/Statistics.h
+++ b/src/Statistics.h
@@ -406,6 +406,8 @@ enum hipVersions {
   HIP_6030 = 6030,
   HIP_6040 = 6040,
   HIP_7000 = 7000,
+  HIP_7010 = 7010,
+  HIP_7020 = 7020,
   HIP_7120 = 7120,
   HIP_7130 = 7130,
   HIP_LATEST = HIP_7000,

--- a/tests/unit_tests/synthetic/driver_enums.cu
+++ b/tests/unit_tests/synthetic/driver_enums.cu
@@ -1257,6 +1257,15 @@ int main() {
   CUdriverProcAddressQueryResult GET_PROC_ADDRESS_VERSION_NOT_SUFFICIENT = CU_GET_PROC_ADDRESS_VERSION_NOT_SUFFICIENT;
 #endif
 
+#if CUDA_VERSION >= 12020
+  // CHECK: hipMemLocationType MEM_LOCATION_TYPE_HOST = hipMemLocationTypeHost;
+  // CHECK-NEXT: hipMemLocationType MEM_LOCATION_TYPE_HOST_NUMA = hipMemLocationTypeHostNuma;
+  // CHECK-NEXT: hipDeviceAttribute_t DEVICE_ATTRIBUTE_HOST_NUMA_ID = hipDeviceAttributeHostNumaId;
+  CUmemLocationType MEM_LOCATION_TYPE_HOST = CU_MEM_LOCATION_TYPE_HOST;
+  CUmemLocationType MEM_LOCATION_TYPE_HOST_NUMA = CU_MEM_LOCATION_TYPE_HOST_NUMA;
+  CUdevice_attribute DEVICE_ATTRIBUTE_HOST_NUMA_ID = CU_DEVICE_ATTRIBUTE_HOST_NUMA_ID;
+#endif
+
 #if CUDA_VERSION >= 12030
   // CHECK: hipGraphDependencyType graphDependencyType;
   // CHECK-NEXT: hipGraphDependencyType graphDependencyType_enum;

--- a/tests/unit_tests/synthetic/runtime_defines.cu
+++ b/tests/unit_tests/synthetic/runtime_defines.cu
@@ -415,6 +415,11 @@ int main() {
   int HostRegisterReadOnly = cudaHostRegisterReadOnly;
 #endif
 
+#if CUDA_VERSION >= 12020
+  // CHECK: int DevAttrHostNumaId = hipDeviceAttributeHostNumaId;
+  int DevAttrHostNumaId = cudaDevAttrHostNumaId;
+#endif
+
 #if CUDA_VERSION >= 12030
   // CHECK: int GRAPH_KERNEL_NODE_PORT_DEFAULT = hipGraphKernelNodePortDefault;
   int GRAPH_KERNEL_NODE_PORT_DEFAULT = cudaGraphKernelNodePortDefault;

--- a/tests/unit_tests/synthetic/runtime_enums.cu
+++ b/tests/unit_tests/synthetic/runtime_enums.cu
@@ -946,6 +946,15 @@ int main() {
   cudaDriverEntryPointQueryResult GET_PROC_ADDRESS_VERSION_NOT_SUFFICIENT = cudaDriverEntryPointVersionNotSufficent;
 #endif
 
+#if CUDA_VERSION >= 12020
+  // CHECK: hipMemLocationType MemLocationTypeHost = hipMemLocationTypeHost;
+  // CHECK-NEXT: hipMemLocationType MemLocationTypeHostNuma = hipMemLocationTypeHostNuma;
+  // CHECK-NEXT: hipDeviceAttribute_t DevAttrHostNumaId = hipDeviceAttributeHostNumaId;
+  cudaMemLocationType MemLocationTypeHost = cudaMemLocationTypeHost;
+  cudaMemLocationType MemLocationTypeHostNuma = cudaMemLocationTypeHostNuma;
+  cudaDeviceAttr DevAttrHostNumaId = cudaDevAttrHostNumaId;
+#endif
+
 #if CUDA_VERSION >= 12030
   // CHECK: hipGraphDependencyType graphDependencyType;
   // CHECK-NEXT: hipGraphDependencyType graphDependencyType_enum;


### PR DESCRIPTION
- Backport of the `Host NUMA` constants support to `ROCm 7.0.2.2` release, requested for `RCCL`:
   - `CU_MEM_LOCATION_TYPE_HOST` -> `hipMemLocationTypeHost`
   - `CU_MEM_LOCATION_TYPE_HOST_NUMA` -> `hipMemLocationTypeHostNuma`
   - `CU_DEVICE_ATTRIBUTE_HOST_NUMA_ID` -> `hipDeviceAttributeHostNumaId`
   - and their `Runtime API` counterparts `cudaMemLocationTypeHost`, `cudaMemLocationTypeHostNuma`, and `cudaDevAttrHostNumaId`
- Added `HIP 7.1.0` and `HIP 7.2.0` to the known HIP versions and `HIP_LATEST` is unchanged
- Updated the corresponding tests, regenerated `hipify-perl`, and `Driver` and `Runtime` `CUDA2HIP` docs accordingly
- Tested against `LLVM 20.1.8`